### PR TITLE
chore(mr): prepare v2024.10.1

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -120,7 +120,9 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/riscv64,linux/ppc64le,linux/s390x
+          # HOTFIX: reduce build time to beeing under standard limit of
+          # 6 hours runtime ("timeout-minutes") on GitHub hosted runners.
+          platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,6 +40,13 @@ jobs:
       # with sigstore/fulcio when running outside of PRs.
       id-token: write
 
+    # Allow to build longer than 6 hours, but this is only possible
+    # with self-hosted runners. 1440 min = 24 h. For details, see:
+    # https://github.com/orgs/community/discussions/26679
+    # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions
+    # https://docs.github.com/en/actions/administering-github-actions/usage-limits-billing-and-administration
+    timeout-minutes: 1440
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -120,7 +120,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/riscv64,linux/ppc64le
+          platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/riscv64,linux/ppc64le,linux/s390x
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -120,7 +120,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm/v7
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -120,7 +120,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm/v7
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -120,7 +120,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/riscv64
+          platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/riscv64,linux/ppc64le
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -82,6 +82,12 @@ jobs:
         if: github.event_name != 'pull_request'
         run: cosign version
 
+      # Install QEMU static binaries for multi-arch image build
+      # https://github.com/docker/setup-qemu-action
+      # https://docs.docker.com/build/ci/github-actions/multi-platform
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
       # https://github.com/docker/setup-buildx-action
@@ -114,6 +120,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -120,7 +120,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/riscv64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ docker build -t tiacsys/readourdocs-docker-images:local .
 ```
 
 This will take quite a long time, mostly due to LaTeX dependencies. The
-resulting image will be at least around 12GB.
+resulting image will be at least around 17GB.
 
 Once your image is built, you can test your image locally by running a shell in
 a container using your new image:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,15 +13,52 @@ If you would like to fix a bug or add a feature to our build images, see
 ## Testing Locally
 
 If you'd like to add a feature to any of the images, you'll need to verify the
-image works locally first. After making changes to the ``Dockerfile``, you can
-build your image with:
+image works locally first. To build multi-platform images, you first need to
+make sure that your [Docker environment is set up to support it](
+https://docs.docker.com/build/building/multi-platform/#prerequisites),
+e.g. QEMU and a custom builder with self contained containerd image store.
+To create such a custom builder, use the ``docker buildx create`` command:
 
 ```bash
-docker build -t tiacsys/readourdocs-docker-images:local .
+docker buildx create --name rod-ctn-builder --driver docker-container \
+                     --bootstrap --use
 ```
 
-This will take quite a long time, mostly due to LaTeX dependencies. The
-resulting image will be at least around 17GB.
+After making changes to the ``Dockerfile``, you can build your image with:
+
+```bash
+docker buildx build --tag tiacsys/readourdocs-docker-images:local \
+                    --platform linux/amd64 \
+                    --builder rod-ctn-builder --load .
+```
+
+**ERROR: docker exporter does not currently support exporting manifest lists**
+
+Unfortunately, it is impossible to run that multi-platform image as local
+container. Container images with support for multiple architectures are part of
+the [OCI specification](
+https://github.com/opencontainers/image-spec/blob/main/image-index.md) and
+Docker supports creating these as well. The image index (more commonly referred
+to as the image manifest) contains some metadata about the image itself and an
+array of actual manifests which specify the platform and the image layer
+references. Docker supports creating these but only through the experimental
+new builder, *buildx*.
+
+Buildx has some nice new features like support for better caching between
+images as well as cleaner output during builds. However, it runs completely
+independently of your standard local docker registry. If you run ``docker ps``,
+you’ll see a buildx builder running as a container on your local machine. This
+is a virtual builder that we created using ``docker buildx create``.
+
+**Simple build for native platform**
+
+```bash
+docker build --tag tiacsys/readourdocs-docker-images:local .
+```
+
+This will take quite a long time, mostly due to LaTeX dependencies and required
+rebuilds of components from source code for different platforms. The resulting
+images will be at least around 17GB.
 
 Once your image is built, you can test your image locally by running a shell in
 a container using your new image:
@@ -55,6 +92,8 @@ completely deleted at any time with:
 
 ```bash
 docker image rm tiacsys/readourdocs-docker-images:local
+docker buildx rm rod-ctn-builder
+docker buildx prune --all --force
 docker builder prune --all --force
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ After making changes to the ``Dockerfile``, you can build your image with:
 
 ```bash
 docker buildx build --tag tiacsys/readourdocs-docker-images:local \
-                    --platform linux/amd64,linux/arm/v7,linux/arm64 \
+                    --platform linux/amd64,linux/arm/v7,linux/arm64,linux/riscv64 \
                     --builder rod-ctn-builder --load .
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ After making changes to the ``Dockerfile``, you can build your image with:
 
 ```bash
 docker buildx build --tag tiacsys/readourdocs-docker-images:local \
-                    --platform linux/amd64,linux/arm/v7,linux/arm64,linux/riscv64 \
+                    --platform linux/amd64,linux/arm/v7,linux/arm64,linux/riscv64,linux/ppc64le \
                     --builder rod-ctn-builder --load .
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ After making changes to the ``Dockerfile``, you can build your image with:
 
 ```bash
 docker buildx build --tag tiacsys/readourdocs-docker-images:local \
-                    --platform linux/amd64 \
+                    --platform linux/amd64,linux/arm/v7 \
                     --builder rod-ctn-builder --load .
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ After making changes to the ``Dockerfile``, you can build your image with:
 
 ```bash
 docker buildx build --tag tiacsys/readourdocs-docker-images:local \
-                    --platform linux/amd64,linux/arm/v7,linux/arm64,linux/riscv64,linux/ppc64le \
+                    --platform linux/amd64,linux/arm/v7,linux/arm64,linux/riscv64,linux/ppc64le,linux/s390x \
                     --builder rod-ctn-builder --load .
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ After making changes to the ``Dockerfile``, you can build your image with:
 
 ```bash
 docker buildx build --tag tiacsys/readourdocs-docker-images:local \
-                    --platform linux/amd64,linux/arm/v7 \
+                    --platform linux/amd64,linux/arm/v7,linux/arm64 \
                     --builder rod-ctn-builder --load .
 ```
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@
 #  -- TARGETPLATFORM=linux/amd64: TARGETOS=linux, TARGETARCH=amd64, TARGETVARIANT=
 #  -- TARGETPLATFORM=linux/arm/v7: TARGETOS=linux, TARGETARCH=arm, TARGETVARIANT=v7
 #  -- TARGETPLATFORM=linux/arm64: TARGETOS=linux, TARGETARCH=arm64, TARGETVARIANT=
+#  -- TARGETPLATFORM=linux/riscv64: TARGETOS=linux, TARGETARCH=riscv64, TARGETVARIANT=
 #
 
 # ############################################################################
@@ -876,6 +877,129 @@ LABEL nodejs.version_22=$ROD_NODEJS_VERSION_22
 # Set default Node.js version
 RUN asdf local nodejs $ROD_NODEJS_VERSION_22
 RUN asdf list  nodejs
+
+# ############################################################################
+
+#
+# Ruby runtime versions
+#
+
+# Install Ruby versions
+RUN asdf install ruby $ROD_RUBY_VERSION_33 && \
+    asdf global  ruby $ROD_RUBY_VERSION_33 && \
+    asdf reshim  ruby
+
+# Adding labels for external usage
+LABEL ruby.version_33=$ROD_RUBY_VERSION_33
+
+# Set default Ruby version
+RUN asdf local ruby $ROD_RUBY_VERSION_33
+RUN asdf list  ruby
+
+# ############################################################################
+
+#
+# Python and PyPy runtime versions
+#
+
+# Install Python versions
+RUN asdf install python $ROD_PYTHON_VERSION_27 && \
+    asdf global  python $ROD_PYTHON_VERSION_27 && \
+    asdf reshim  python
+
+RUN asdf install python $ROD_PYTHON_VERSION_310 && \
+    asdf global  python $ROD_PYTHON_VERSION_310 && \
+    asdf reshim  python
+
+RUN asdf install python $ROD_PYTHON_VERSION_312 && \
+    asdf global  python $ROD_PYTHON_VERSION_312 && \
+    asdf reshim  python
+
+# Python2 dependencies are hardcoded because Python2 is
+# deprecated. Updating them to their latest versions may raise
+# incompatibility issues.
+RUN asdf local python $ROD_PYTHON_VERSION_27 && \
+    pip install --upgrade pip==20.3.4 && \
+    pip install --upgrade setuptools==44.1.1 && \
+    pip install --upgrade virtualenv==20.15.1 && \
+    pip install --upgrade wheel==0.37.1 && \
+    pip install --upgrade poetry==1.1.15
+
+# Install Python package versions
+RUN asdf local python $ROD_PYTHON_VERSION_310 && \
+    pip install --upgrade pip==$ROD_PIP_VERSION && \
+    pip install --upgrade setuptools==$ROD_SETUPTOOLS_VERSION && \
+    pip install --upgrade virtualenv==$ROD_VIRTUALENV_VERSION && \
+    pip install --upgrade wheel==$ROD_WHEEL_VERSION && \
+    pip install --upgrade poetry==$ROD_POETRY_VERSION && \
+    pip install --upgrade west==$ROD_WEST_VERSION
+
+RUN asdf local python $ROD_PYTHON_VERSION_312 && \
+    pip install --upgrade pip==$ROD_PIP_VERSION && \
+    pip install --upgrade setuptools==$ROD_SETUPTOOLS_VERSION && \
+    pip install --upgrade virtualenv==$ROD_VIRTUALENV_VERSION && \
+    pip install --upgrade wheel==$ROD_WHEEL_VERSION && \
+    pip install --upgrade poetry==$ROD_POETRY_VERSION && \
+    pip install --upgrade west==$ROD_WEST_VERSION
+
+# Adding labels for external usage
+LABEL python.version_27=$ROD_PYTHON_VERSION_27
+LABEL python.version_310=$ROD_PYTHON_VERSION_310
+LABEL python.version_312=$ROD_PYTHON_VERSION_312
+LABEL python.pip=$ROD_PIP_VERSION
+LABEL python.setuptools=$ROD_SETUPTOOLS_VERSION
+LABEL python.virtualenv=$ROD_VIRTUALENV_VERSION
+LABEL python.wheel=$ROD_WHEEL_VERSION
+LABEL python.poetry=$ROD_POETRY_VERSION
+LABEL python.west=$ROD_WEST_VERSION
+
+# Set default Python version
+RUN asdf local python $ROD_PYTHON_VERSION_312
+RUN asdf list  python
+
+# ############################################################################
+#
+# RISC-V 64-bit architecture maintenance
+#
+# ############################################################################
+
+FROM base AS build-riscv64
+
+# ############################################################################
+
+#
+# Rust runtime versions
+#
+
+# Install Rust versions
+RUN asdf install rust $ROD_RUST_VERSION_2024 && \
+    asdf global  rust $ROD_RUST_VERSION_2024 && \
+    asdf reshim  rust
+
+# Adding labels for external usage
+LABEL rust.version_2024=$ROD_RUST_VERSION_2024
+
+# Set default Rust version
+RUN asdf local rust $ROD_RUST_VERSION_2024
+RUN asdf list  rust
+
+# ############################################################################
+
+#
+# Golang runtime versions
+#
+
+# Install Golang versions
+RUN asdf install golang $ROD_GOLANG_VERSION_2024 && \
+    asdf global  golang $ROD_GOLANG_VERSION_2024 && \
+    asdf reshim  golang
+
+# Adding labels for external usage
+LABEL golang.version_2024=$ROD_GOLANG_VERSION_2024
+
+# Set default Golang version
+RUN asdf local golang $ROD_GOLANG_VERSION_2024
+RUN asdf list  golang
 
 # ############################################################################
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -472,33 +472,6 @@ RUN asdf list  ruby
 # ############################################################################
 
 #
-# PyPA pipx for Python runtime version
-# https://repology.org/project/pipx/versions
-# https://pipx.pypa.io/stable/installation
-# https://github.com/pypa/pipx
-#
-
-# Define pipx version to be installed via asdf
-ENV ROD_PIPX_VERSION=1.7.1
-
-# Install pipx version
-RUN asdf install pipx $ROD_PIPX_VERSION && \
-    asdf global  pipx $ROD_PIPX_VERSION && \
-    asdf reshim  pipx
-
-# Adding labels for external usage
-LABEL pipx.version=$ROD_PIPX_VERSION
-
-# Set default pipx version
-RUN asdf local pipx $ROD_PIPX_VERSION
-RUN asdf list  pipx
-
-# Ensure PATH environment variable for pipx
-RUN pipx ensurepath
-
-# ############################################################################
-
-#
 # Python runtime versions
 # https://www.python.org/downloads
 # https://devguide.python.org/versions
@@ -608,6 +581,46 @@ LABEL python.virtualenv=$ROD_VIRTUALENV_VERSION
 LABEL python.wheel=$ROD_WHEEL_VERSION
 LABEL python.poetry=$ROD_POETRY_VERSION
 LABEL python.west=$ROD_WEST_VERSION
+
+# Set default Python version
+RUN asdf local python $ROD_PYTHON_VERSION_312
+RUN asdf list  python
+
+# ############################################################################
+
+#
+# PyPA pipx for Python runtime version
+# https://repology.org/project/pipx/versions
+# https://pipx.pypa.io/stable/installation
+# https://github.com/pypa/pipx
+#
+
+# Define pipx version to be installed via asdf
+ENV ROD_PIPX_VERSION=1.7.1
+ENV ROD_PIPX_ARGCOMPLETE_VERSION=3.5.0
+
+# Install pipx version
+RUN asdf install pipx $ROD_PIPX_VERSION && \
+    asdf global  pipx $ROD_PIPX_VERSION && \
+    asdf reshim  pipx
+
+# Adding labels for external usage
+LABEL pipx.version=$ROD_PIPX_VERSION
+LABEL pipx_argcomplete.version=$ROD_PIPX_ARGCOMPLETE_VERSION
+
+# Set default pipx version
+RUN asdf local pipx $ROD_PIPX_VERSION
+RUN asdf list  pipx
+
+# Ensure PATH environment variable for pipx
+RUN pipx ensurepath
+
+# Enabling shell completions for pipx
+RUN pipx install argcomplete==$ROD_PIPX_ARGCOMPLETE_VERSION && \
+    pipx pin     argcomplete && \
+    echo 'eval "$(register-python-argcomplete pipx)"' >> /home/docs/.bashrc
+
+# ############################################################################
 
 # Define Python package versions to be installed via pipx
 ENV ROD_POETRY_VERSION_18=1.8.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@
 #  -- TARGETPLATFORM=linux/arm/v7: TARGETOS=linux, TARGETARCH=arm, TARGETVARIANT=v7
 #  -- TARGETPLATFORM=linux/arm64: TARGETOS=linux, TARGETARCH=arm64, TARGETVARIANT=
 #  -- TARGETPLATFORM=linux/riscv64: TARGETOS=linux, TARGETARCH=riscv64, TARGETVARIANT=
+#  -- TARGETPLATFORM=linux/ppc64le: TARGETOS=linux, TARGETARCH=ppc64le, TARGETVARIANT=
 #
 
 # ############################################################################
@@ -1000,6 +1001,147 @@ LABEL golang.version_2024=$ROD_GOLANG_VERSION_2024
 # Set default Golang version
 RUN asdf local golang $ROD_GOLANG_VERSION_2024
 RUN asdf list  golang
+
+# ############################################################################
+
+#
+# Ruby runtime versions
+#
+
+# Install Ruby versions
+RUN asdf install ruby $ROD_RUBY_VERSION_33 && \
+    asdf global  ruby $ROD_RUBY_VERSION_33 && \
+    asdf reshim  ruby
+
+# Adding labels for external usage
+LABEL ruby.version_33=$ROD_RUBY_VERSION_33
+
+# Set default Ruby version
+RUN asdf local ruby $ROD_RUBY_VERSION_33
+RUN asdf list  ruby
+
+# ############################################################################
+
+#
+# Python and PyPy runtime versions
+#
+
+# Install Python versions
+RUN asdf install python $ROD_PYTHON_VERSION_27 && \
+    asdf global  python $ROD_PYTHON_VERSION_27 && \
+    asdf reshim  python
+
+RUN asdf install python $ROD_PYTHON_VERSION_310 && \
+    asdf global  python $ROD_PYTHON_VERSION_310 && \
+    asdf reshim  python
+
+RUN asdf install python $ROD_PYTHON_VERSION_312 && \
+    asdf global  python $ROD_PYTHON_VERSION_312 && \
+    asdf reshim  python
+
+# Python2 dependencies are hardcoded because Python2 is
+# deprecated. Updating them to their latest versions may raise
+# incompatibility issues.
+RUN asdf local python $ROD_PYTHON_VERSION_27 && \
+    pip install --upgrade pip==20.3.4 && \
+    pip install --upgrade setuptools==44.1.1 && \
+    pip install --upgrade virtualenv==20.15.1 && \
+    pip install --upgrade wheel==0.37.1 && \
+    pip install --upgrade poetry==1.1.15
+
+# Install Python package versions
+RUN asdf local python $ROD_PYTHON_VERSION_310 && \
+    pip install --upgrade pip==$ROD_PIP_VERSION && \
+    pip install --upgrade setuptools==$ROD_SETUPTOOLS_VERSION && \
+    pip install --upgrade virtualenv==$ROD_VIRTUALENV_VERSION && \
+    pip install --upgrade wheel==$ROD_WHEEL_VERSION && \
+    pip install --upgrade poetry==$ROD_POETRY_VERSION && \
+    pip install --upgrade west==$ROD_WEST_VERSION
+
+RUN asdf local python $ROD_PYTHON_VERSION_312 && \
+    pip install --upgrade pip==$ROD_PIP_VERSION && \
+    pip install --upgrade setuptools==$ROD_SETUPTOOLS_VERSION && \
+    pip install --upgrade virtualenv==$ROD_VIRTUALENV_VERSION && \
+    pip install --upgrade wheel==$ROD_WHEEL_VERSION && \
+    pip install --upgrade poetry==$ROD_POETRY_VERSION && \
+    pip install --upgrade west==$ROD_WEST_VERSION
+
+# Adding labels for external usage
+LABEL python.version_27=$ROD_PYTHON_VERSION_27
+LABEL python.version_310=$ROD_PYTHON_VERSION_310
+LABEL python.version_312=$ROD_PYTHON_VERSION_312
+LABEL python.pip=$ROD_PIP_VERSION
+LABEL python.setuptools=$ROD_SETUPTOOLS_VERSION
+LABEL python.virtualenv=$ROD_VIRTUALENV_VERSION
+LABEL python.wheel=$ROD_WHEEL_VERSION
+LABEL python.poetry=$ROD_POETRY_VERSION
+LABEL python.west=$ROD_WEST_VERSION
+
+# Set default Python version
+RUN asdf local python $ROD_PYTHON_VERSION_312
+RUN asdf list  python
+
+# ############################################################################
+#
+# IBM POWER8 architecture maintenance
+#
+# ############################################################################
+
+FROM base AS build-ppc64le
+
+# ############################################################################
+
+#
+# Rust runtime versions
+#
+
+# Install Rust versions
+RUN asdf install rust $ROD_RUST_VERSION_2024 && \
+    asdf global  rust $ROD_RUST_VERSION_2024 && \
+    asdf reshim  rust
+
+# Adding labels for external usage
+LABEL rust.version_2024=$ROD_RUST_VERSION_2024
+
+# Set default Rust version
+RUN asdf local rust $ROD_RUST_VERSION_2024
+RUN asdf list  rust
+
+# ############################################################################
+
+#
+# Golang runtime versions
+#
+
+# Install Golang versions
+RUN asdf install golang $ROD_GOLANG_VERSION_2024 && \
+    asdf global  golang $ROD_GOLANG_VERSION_2024 && \
+    asdf reshim  golang
+
+# Adding labels for external usage
+LABEL golang.version_2024=$ROD_GOLANG_VERSION_2024
+
+# Set default Golang version
+RUN asdf local golang $ROD_GOLANG_VERSION_2024
+RUN asdf list  golang
+
+# ############################################################################
+
+#
+# Node.js runtime versions
+#
+
+# Install Node.js versions
+RUN asdf install nodejs $ROD_NODEJS_VERSION_22 && \
+    asdf global  nodejs $ROD_NODEJS_VERSION_22 && \
+    asdf reshim  nodejs
+
+# Adding labels for external usage
+LABEL nodejs.version_22=$ROD_NODEJS_VERSION_22
+
+# Set default Node.js version
+RUN asdf local nodejs $ROD_NODEJS_VERSION_22
+RUN asdf list  nodejs
 
 # ############################################################################
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,12 @@
 # Read Our Docs - Environment base
 #
-#  -- derived from Read The Docs base environment
-#  -- see: https://hub.docker.com/r/readthedocs/build/tags
-#  -- see: https://github.com/readthedocs/readthedocs-docker-images
-#
-#  -- derived from Ubuntu official Docker image
+#  -- derived from official Ubuntu Docker image
 #  -- see: https://hub.docker.com/_/ubuntu/tags
 #  -- see: https://github.com/docker-library/official-images
 #
-FROM readthedocs/build:ubuntu-24.04-2024.06.17
+FROM ubuntu:noble-20240904.1
 LABEL mantainer="Stephan Linz <stephan.linz@tiac-systems.de>"
-LABEL version="2024.10.0"
+LABEL version="unstable"
 
 LABEL org.opencontainers.image.vendor="TiaC Systems Network"
 LABEL org.opencontainers.image.authors="Stephan Linz <stephan.linz@tiac-systems.de>"
@@ -29,8 +25,51 @@ WORKDIR /
 # System dependencies
 RUN apt-get -y update
 RUN apt-get -y dist-upgrade
+RUN apt-get -y install \
+    software-properties-common \
+    vim
 RUN apt-get -y autoremove --purge
 RUN apt-get clean
+
+# Install requirements
+RUN apt-get -y install \
+    build-essential \
+    bzr \
+    curl \
+    doxygen \
+    g++ \
+    git-core \
+    graphviz-dev \
+    libbz2-dev \
+    libcairo2-dev \
+    libenchant-2-2 \
+    libevent-dev \
+    libffi-dev \
+    libfreetype6 \
+    libfreetype6-dev \
+    libgraphviz-dev \
+    libjpeg8-dev \
+    libjpeg-dev \
+    liblcms2-dev \
+    libmysqlclient-dev \
+    libpq-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    libtiff5-dev \
+    libwebp-dev \
+    libxml2-dev \
+    libxslt1-dev \
+    libxslt-dev \
+    mercurial \
+    pandoc \
+    pkg-config \
+    postgresql-client \
+    subversion \
+    zlib1g-dev
+RUN apt-get -y autoremove --purge
+RUN apt-get clean
+
+# ############################################################################
 
 # Localization dependencies
 RUN apt-get -y install \
@@ -52,34 +91,34 @@ RUN locale -a
 
 # Tools for international spelling check
 RUN apt-get -y install \
-      aspell \
-      enchant-2 \
-      hunspell
+    aspell \
+    enchant-2 \
+    hunspell
 RUN apt-get -y autoremove --purge
 RUN apt-get clean
 
 # Dictionaries for spelling check -- split to reduce image layer size
 RUN apt-get -y install \
-      aspell-en \
-      hunspell-en-us \
-      hunspell-en-med
+    aspell-en \
+    hunspell-en-us \
+    hunspell-en-med
 RUN apt-get -y autoremove --purge
 RUN apt-get clean
 
 # Dictionaries for spelling check -- split to reduce image layer size
 RUN apt-get -y install \
-      aspell-de \
-      hunspell-de-de \
-      hunspell-de-med \
-      myspell-de-de-1901
+    aspell-de \
+    hunspell-de-de \
+    hunspell-de-med \
+    myspell-de-de-1901
 RUN apt-get -y autoremove --purge
 RUN apt-get clean
 
 # Dictionaries for spelling check -- split to reduce image layer size
 RUN apt-get -y install \
-      wamerican-huge \
-      wgerman-medical \
-      wngerman
+    wamerican-huge \
+    wgerman-medical \
+    wngerman
 RUN apt-get -y autoremove --purge
 RUN apt-get clean
 
@@ -106,13 +145,13 @@ RUN apt-get clean
 # swig: is required for different purposes
 # https://github.com/readthedocs/readthedocs-docker-images/issues/15
 RUN apt-get -y install \
-      graphviz \
-      imagemagick \
-      librsvg2-bin \
-      pdf2svg \
-      plantuml \
-      poppler-utils \
-      swig
+    graphviz \
+    imagemagick \
+    librsvg2-bin \
+    pdf2svg \
+    plantuml \
+    poppler-utils \
+    swig
 RUN apt-get -y autoremove --purge
 RUN apt-get clean
 
@@ -120,17 +159,44 @@ RUN apt-get clean
 
 # LaTeX -- split to reduce image layer size
 RUN apt-get -y install \
-    texlive-fonts-extra \
+    texlive-fonts-extra
+RUN apt-get -y install \
     texlive-fonts-recommended
 RUN apt-get -y install \
-    texlive-lang-english \
+    texlive-lang-english
+RUN apt-get -y install \
     texlive-lang-european
 RUN apt-get -y install \
-    texlive-pictures \
-    texlive-science \
+    texlive-lang-japanese
+RUN apt-get -y install \
+    texlive-pictures
+RUN apt-get -y install \
+    texlive-science
+RUN apt-get -y install \
     texlive-xetex
+RUN apt-get -y install \
+    texlive-full
 RUN apt-get -y autoremove --purge
 RUN apt-get clean
+
+# lmodern: extra fonts
+# https://github.com/rtfd/readthedocs.org/issues/5494
+#
+# xindy: is useful to generate non-ascii indexes
+# https://github.com/rtfd/readthedocs.org/issues/4454
+#
+# fonts-noto-cjk-extra
+# fonts-hanazono: chinese fonts
+# https://github.com/readthedocs/readthedocs.org/issues/6319
+RUN apt-get -y install \
+    fonts-symbola \
+    lmodern \
+    latex-cjk-chinese-arphic-bkai00mp \
+    latex-cjk-chinese-arphic-gbsn00lp \
+    latex-cjk-chinese-arphic-gkai00mp \
+    fonts-noto-cjk-extra \
+    fonts-hanazono \
+    xindy
 
 # latexmk: is needed to generate LaTeX documents
 # https://github.com/readthedocs/readthedocs.org/issues/4454
@@ -141,10 +207,53 @@ RUN apt-get clean
 
 # ############################################################################
 
-# asdf Python 3.6.15 extra requirements
+# asdf Python extra requirements
+# https://github.com/pyenv/pyenv/wiki#suggested-build-environment
 # https://github.com/pyenv/pyenv/issues/1889#issuecomment-833587851
 RUN apt-get install -y \
-    clang
+    clang \
+    liblzma-dev \
+    libncursesw5-dev \
+    libssl-dev \
+    libxmlsec1-dev \
+    llvm \
+    make \
+    tk-dev \
+    wget \
+    xz-utils
+RUN apt-get -y autoremove --purge
+RUN apt-get clean
+
+# asdf nodejs extra requirements
+# https://github.com/asdf-vm/asdf-nodejs#linux-debian
+RUN apt-get install -y \
+    dirmngr \
+    gpg
+RUN apt-get -y autoremove --purge
+RUN apt-get clean
+
+# asdf Golang extra requirements
+# https://github.com/kennyp/asdf-golang#linux-debian
+RUN apt-get install -y \
+    coreutils
+RUN apt-get -y autoremove --purge
+RUN apt-get clean
+
+# asdf Ruby extra requirements
+# https://github.com/rbenv/ruby-build/wiki#suggested-build-environment
+RUN apt-get install -y \
+    autoconf \
+    patch \
+    rustc \
+    libssl-dev \
+    libyaml-dev \
+    libreadline6-dev \
+    libgmp-dev \
+    libncurses5-dev \
+    libgdbm6 \
+    libgdbm-dev \
+    libdb-dev \
+    uuid-dev
 RUN apt-get -y autoremove --purge
 RUN apt-get clean
 
@@ -186,17 +295,42 @@ RUN apt-get clean
 # asdf version manager in docs user space.
 #
 
+# UID and GID from readthedocs/user
+RUN groupadd --gid 205 docs
+RUN useradd -m --uid 1005 --gid 205 docs
+
 USER docs
 WORKDIR /home/docs
+
+# Install asdf
+RUN git clone https://github.com/asdf-vm/asdf.git ~/.asdf --depth 1 --branch v0.14.1
+RUN echo ". /home/docs/.asdf/asdf.sh" >> /home/docs/.bashrc
+RUN echo ". /home/docs/.asdf/completions/asdf.bash" >> /home/docs/.bashrc
+
+# Activate asdf in current session
+ENV PATH /home/docs/.asdf/shims:/home/docs/.asdf/bin:$PATH
+
+# Install asdf plugins
+RUN asdf plugin add pipx   https://github.com/yozachar/asdf-pipx.git
+RUN asdf plugin add python https://github.com/asdf-community/asdf-python.git
+RUN asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git
+RUN asdf plugin add rust   https://github.com/code-lever/asdf-rust.git
+RUN asdf plugin add golang https://github.com/asdf-community/asdf-golang.git
+RUN asdf plugin add ruby   https://github.com/asdf-vm/asdf-ruby.git
+
+# Create directories for languages installations
+RUN mkdir -p /home/docs/.asdf/installs/pipx && \
+    mkdir -p /home/docs/.asdf/installs/python && \
+    mkdir -p /home/docs/.asdf/installs/nodejs && \
+    mkdir -p /home/docs/.asdf/installs/rust && \
+    mkdir -p /home/docs/.asdf/installs/golang && \
+    mkdir -p /home/docs/.asdf/installs/ruby
 
 # Upgrade asdf version manager
 # https://github.com/asdf-vm/asdf
 RUN asdf update
 RUN asdf plugin update --all
 RUN asdf version
-
-# Install asdf plugins
-RUN asdf plugin add pipx https://github.com/yozachar/asdf-pipx.git
 
 # ############################################################################
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@
 #
 #  -- TARGETPLATFORM=linux/amd64: TARGETOS=linux, TARGETARCH=amd64, TARGETVARIANT=
 #  -- TARGETPLATFORM=linux/arm/v7: TARGETOS=linux, TARGETARCH=arm, TARGETVARIANT=v7
+#  -- TARGETPLATFORM=linux/arm64: TARGETOS=linux, TARGETARCH=arm64, TARGETVARIANT=
 #
 
 # ############################################################################
@@ -701,6 +702,155 @@ RUN asdf list  rust
 RUN asdf install golang $ROD_GOLANG_VERSION_2024 && \
     asdf global  golang $ROD_GOLANG_VERSION_2024 && \
     asdf reshim  golang
+
+# Adding labels for external usage
+LABEL golang.version_2024=$ROD_GOLANG_VERSION_2024
+
+# Set default Golang version
+RUN asdf local golang $ROD_GOLANG_VERSION_2024
+RUN asdf list  golang
+
+# ############################################################################
+
+#
+# Node.js runtime versions
+#
+
+# Install Node.js versions
+RUN asdf install nodejs $ROD_NODEJS_VERSION_22 && \
+    asdf global  nodejs $ROD_NODEJS_VERSION_22 && \
+    asdf reshim  nodejs
+
+# Adding labels for external usage
+LABEL nodejs.version_22=$ROD_NODEJS_VERSION_22
+
+# Set default Node.js version
+RUN asdf local nodejs $ROD_NODEJS_VERSION_22
+RUN asdf list  nodejs
+
+# ############################################################################
+
+#
+# Ruby runtime versions
+#
+
+# Install Ruby versions
+RUN asdf install ruby $ROD_RUBY_VERSION_33 && \
+    asdf global  ruby $ROD_RUBY_VERSION_33 && \
+    asdf reshim  ruby
+
+# Adding labels for external usage
+LABEL ruby.version_33=$ROD_RUBY_VERSION_33
+
+# Set default Ruby version
+RUN asdf local ruby $ROD_RUBY_VERSION_33
+RUN asdf list  ruby
+
+# ############################################################################
+
+#
+# Python and PyPy runtime versions
+#
+
+# Install Python versions
+RUN asdf install python $ROD_PYTHON_VERSION_27 && \
+    asdf global  python $ROD_PYTHON_VERSION_27 && \
+    asdf reshim  python
+
+RUN asdf install python $ROD_PYTHON_VERSION_310 && \
+    asdf global  python $ROD_PYTHON_VERSION_310 && \
+    asdf reshim  python
+
+RUN asdf install python $ROD_PYTHON_VERSION_312 && \
+    asdf global  python $ROD_PYTHON_VERSION_312 && \
+    asdf reshim  python
+
+# Python2 dependencies are hardcoded because Python2 is
+# deprecated. Updating them to their latest versions may raise
+# incompatibility issues.
+RUN asdf local python $ROD_PYTHON_VERSION_27 && \
+    pip install --upgrade pip==20.3.4 && \
+    pip install --upgrade setuptools==44.1.1 && \
+    pip install --upgrade virtualenv==20.15.1 && \
+    pip install --upgrade wheel==0.37.1 && \
+    pip install --upgrade poetry==1.1.15
+
+# Install Python package versions
+RUN asdf local python $ROD_PYTHON_VERSION_310 && \
+    pip install --upgrade pip==$ROD_PIP_VERSION && \
+    pip install --upgrade setuptools==$ROD_SETUPTOOLS_VERSION && \
+    pip install --upgrade virtualenv==$ROD_VIRTUALENV_VERSION && \
+    pip install --upgrade wheel==$ROD_WHEEL_VERSION && \
+    pip install --upgrade poetry==$ROD_POETRY_VERSION && \
+    pip install --upgrade west==$ROD_WEST_VERSION
+
+RUN asdf local python $ROD_PYTHON_VERSION_312 && \
+    pip install --upgrade pip==$ROD_PIP_VERSION && \
+    pip install --upgrade setuptools==$ROD_SETUPTOOLS_VERSION && \
+    pip install --upgrade virtualenv==$ROD_VIRTUALENV_VERSION && \
+    pip install --upgrade wheel==$ROD_WHEEL_VERSION && \
+    pip install --upgrade poetry==$ROD_POETRY_VERSION && \
+    pip install --upgrade west==$ROD_WEST_VERSION
+
+# Adding labels for external usage
+LABEL python.version_27=$ROD_PYTHON_VERSION_27
+LABEL python.version_310=$ROD_PYTHON_VERSION_310
+LABEL python.version_312=$ROD_PYTHON_VERSION_312
+LABEL python.pip=$ROD_PIP_VERSION
+LABEL python.setuptools=$ROD_SETUPTOOLS_VERSION
+LABEL python.virtualenv=$ROD_VIRTUALENV_VERSION
+LABEL python.wheel=$ROD_WHEEL_VERSION
+LABEL python.poetry=$ROD_POETRY_VERSION
+LABEL python.west=$ROD_WEST_VERSION
+
+# Set default Python version
+RUN asdf local python $ROD_PYTHON_VERSION_312
+RUN asdf list  python
+
+# ############################################################################
+#
+# ARMv8 64-bit architecture maintenance
+#
+# ############################################################################
+
+FROM base AS build-arm64
+
+# ############################################################################
+
+#
+# Rust runtime versions
+#
+
+# Install Rust versions
+RUN asdf install rust $ROD_RUST_VERSION_2024 && \
+    asdf global  rust $ROD_RUST_VERSION_2024 && \
+    asdf reshim  rust
+
+# Adding labels for external usage
+LABEL rust.version_2024=$ROD_RUST_VERSION_2024
+
+# Set default Rust version
+RUN asdf local rust $ROD_RUST_VERSION_2024
+RUN asdf list  rust
+
+# ############################################################################
+
+#
+# Golang runtime versions
+#
+
+# HOTFIX: Avoid silent failure, with reason inside of curl
+# <- curl: (55) Send failure: Broken pipe
+# <- OpenSSL SSL_write: Broken pipe, errno 32
+RUN echo "--insecure" > /home/docs/.curlrc
+
+# Install Golang versions
+RUN asdf install golang $ROD_GOLANG_VERSION_2024 && \
+    asdf global  golang $ROD_GOLANG_VERSION_2024 && \
+    asdf reshim  golang
+
+# HOTFIX: Revert silent failure hotfix from above
+RUN rm -f /home/docs/.curlrc
 
 # Adding labels for external usage
 LABEL golang.version_2024=$ROD_GOLANG_VERSION_2024

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@
 #  -- see: https://docs.docker.com/build/building/variables/#multi-platform-build-arguments
 #
 #  -- TARGETPLATFORM=linux/amd64: TARGETOS=linux, TARGETARCH=amd64, TARGETVARIANT=
+#  -- TARGETPLATFORM=linux/arm/v7: TARGETOS=linux, TARGETARCH=arm, TARGETVARIANT=v7
 #
 
 # ############################################################################
@@ -653,6 +654,147 @@ LABEL python.version_310=$ROD_PYTHON_VERSION_310
 LABEL python.version_312=$ROD_PYTHON_VERSION_312
 LABEL pypy.version_2=$ROD_PYPY_VERSION_2
 LABEL pypy.version_3=$ROD_PYPY_VERSION_3
+LABEL python.pip=$ROD_PIP_VERSION
+LABEL python.setuptools=$ROD_SETUPTOOLS_VERSION
+LABEL python.virtualenv=$ROD_VIRTUALENV_VERSION
+LABEL python.wheel=$ROD_WHEEL_VERSION
+LABEL python.poetry=$ROD_POETRY_VERSION
+LABEL python.west=$ROD_WEST_VERSION
+
+# Set default Python version
+RUN asdf local python $ROD_PYTHON_VERSION_312
+RUN asdf list  python
+
+# ############################################################################
+#
+# ARMv7 32-bit architecture maintenance
+#
+# ############################################################################
+
+FROM base AS build-arm
+
+# ############################################################################
+
+#
+# Rust runtime versions
+#
+
+# Install Rust versions
+RUN asdf install rust $ROD_RUST_VERSION_2024 && \
+    asdf global  rust $ROD_RUST_VERSION_2024 && \
+    asdf reshim  rust
+
+# Adding labels for external usage
+LABEL rust.version_2024=$ROD_RUST_VERSION_2024
+
+# Set default Rust version
+RUN asdf local rust $ROD_RUST_VERSION_2024
+RUN asdf list  rust
+
+# ############################################################################
+
+#
+# Golang runtime versions
+#
+
+# Install Golang versions
+RUN asdf install golang $ROD_GOLANG_VERSION_2024 && \
+    asdf global  golang $ROD_GOLANG_VERSION_2024 && \
+    asdf reshim  golang
+
+# Adding labels for external usage
+LABEL golang.version_2024=$ROD_GOLANG_VERSION_2024
+
+# Set default Golang version
+RUN asdf local golang $ROD_GOLANG_VERSION_2024
+RUN asdf list  golang
+
+# ############################################################################
+
+#
+# Node.js runtime versions
+#
+
+# Install Node.js versions
+RUN asdf install nodejs $ROD_NODEJS_VERSION_22 && \
+    asdf global  nodejs $ROD_NODEJS_VERSION_22 && \
+    asdf reshim  nodejs
+
+# Adding labels for external usage
+LABEL nodejs.version_22=$ROD_NODEJS_VERSION_22
+
+# Set default Node.js version
+RUN asdf local nodejs $ROD_NODEJS_VERSION_22
+RUN asdf list  nodejs
+
+# ############################################################################
+
+#
+# Ruby runtime versions
+#
+
+# Install Ruby versions
+RUN asdf install ruby $ROD_RUBY_VERSION_33 && \
+    asdf global  ruby $ROD_RUBY_VERSION_33 && \
+    asdf reshim  ruby
+
+# Adding labels for external usage
+LABEL ruby.version_33=$ROD_RUBY_VERSION_33
+
+# Set default Ruby version
+RUN asdf local ruby $ROD_RUBY_VERSION_33
+RUN asdf list  ruby
+
+# ############################################################################
+
+#
+# Python and PyPy runtime versions
+#
+
+# Install Python versions
+RUN asdf install python $ROD_PYTHON_VERSION_27 && \
+    asdf global  python $ROD_PYTHON_VERSION_27 && \
+    asdf reshim  python
+
+RUN asdf install python $ROD_PYTHON_VERSION_310 && \
+    asdf global  python $ROD_PYTHON_VERSION_310 && \
+    asdf reshim  python
+
+RUN asdf install python $ROD_PYTHON_VERSION_312 && \
+    asdf global  python $ROD_PYTHON_VERSION_312 && \
+    asdf reshim  python
+
+# Python2 dependencies are hardcoded because Python2 is
+# deprecated. Updating them to their latest versions may raise
+# incompatibility issues.
+RUN asdf local python $ROD_PYTHON_VERSION_27 && \
+    pip install --upgrade pip==20.3.4 && \
+    pip install --upgrade setuptools==44.1.1 && \
+    pip install --upgrade virtualenv==20.15.1 && \
+    pip install --upgrade wheel==0.37.1 && \
+    pip install --upgrade poetry==1.1.15
+
+# Install Python package versions
+RUN asdf local python $ROD_PYTHON_VERSION_310 && \
+    pip install --upgrade pip==$ROD_PIP_VERSION && \
+    pip install --upgrade setuptools==$ROD_SETUPTOOLS_VERSION && \
+    pip install --upgrade virtualenv==$ROD_VIRTUALENV_VERSION && \
+    pip install --upgrade wheel==$ROD_WHEEL_VERSION && \
+    pip install --upgrade poetry==$ROD_POETRY_VERSION && \
+    pip install --upgrade west==$ROD_WEST_VERSION
+
+RUN asdf local python $ROD_PYTHON_VERSION_312 && \
+    pip install --upgrade pip==$ROD_PIP_VERSION && \
+    pip install --upgrade setuptools==$ROD_SETUPTOOLS_VERSION && \
+    pip install --upgrade virtualenv==$ROD_VIRTUALENV_VERSION && \
+    pip install --upgrade wheel==$ROD_WHEEL_VERSION && \
+    pip install --upgrade poetry==$ROD_POETRY_VERSION && \
+    pip install --upgrade west==$ROD_WEST_VERSION
+
+# Adding labels for external usage
+LABEL python.version_27=$ROD_PYTHON_VERSION_27
+LABEL python.version_310=$ROD_PYTHON_VERSION_310
+LABEL python.version_312=$ROD_PYTHON_VERSION_312
 LABEL python.pip=$ROD_PIP_VERSION
 LABEL python.setuptools=$ROD_SETUPTOOLS_VERSION
 LABEL python.virtualenv=$ROD_VIRTUALENV_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@
 FROM ubuntu:noble-20240904.1 AS base
 
 LABEL mantainer="Stephan Linz <stephan.linz@tiac-systems.de>"
-LABEL version="unstable"
+LABEL version="2024.10.1"
 
 LABEL org.opencontainers.image.vendor="TiaC Systems Network"
 LABEL org.opencontainers.image.authors="Stephan Linz <stephan.linz@tiac-systems.de>"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1224,6 +1224,129 @@ RUN asdf list  python
 
 # ############################################################################
 #
+# IBM z-Systems architecture maintenance
+#
+# ############################################################################
+
+FROM base AS build-s390x
+
+# ############################################################################
+
+#
+# Rust runtime versions
+#
+
+# Install Rust versions
+RUN asdf install rust $ROD_RUST_VERSION_2024 && \
+    asdf global  rust $ROD_RUST_VERSION_2024 && \
+    asdf reshim  rust
+
+# Adding labels for external usage
+LABEL rust.version_2024=$ROD_RUST_VERSION_2024
+
+# Set default Rust version
+RUN asdf local rust $ROD_RUST_VERSION_2024
+RUN asdf list  rust
+
+# ############################################################################
+
+#
+# Node.js runtime versions
+#
+
+# Install Node.js versions
+RUN asdf install nodejs $ROD_NODEJS_VERSION_22 && \
+    asdf global  nodejs $ROD_NODEJS_VERSION_22 && \
+    asdf reshim  nodejs
+
+# Adding labels for external usage
+LABEL nodejs.version_22=$ROD_NODEJS_VERSION_22
+
+# Set default Node.js version
+RUN asdf local nodejs $ROD_NODEJS_VERSION_22
+RUN asdf list  nodejs
+
+# ############################################################################
+
+#
+# Ruby runtime versions
+#
+
+# Install Ruby versions
+RUN asdf install ruby $ROD_RUBY_VERSION_33 && \
+    asdf global  ruby $ROD_RUBY_VERSION_33 && \
+    asdf reshim  ruby
+
+# Adding labels for external usage
+LABEL ruby.version_33=$ROD_RUBY_VERSION_33
+
+# Set default Ruby version
+RUN asdf local ruby $ROD_RUBY_VERSION_33
+RUN asdf list  ruby
+
+# ############################################################################
+
+#
+# Python and PyPy runtime versions
+#
+
+# Install Python versions
+RUN asdf install python $ROD_PYTHON_VERSION_27 && \
+    asdf global  python $ROD_PYTHON_VERSION_27 && \
+    asdf reshim  python
+
+RUN asdf install python $ROD_PYTHON_VERSION_310 && \
+    asdf global  python $ROD_PYTHON_VERSION_310 && \
+    asdf reshim  python
+
+RUN asdf install python $ROD_PYTHON_VERSION_312 && \
+    asdf global  python $ROD_PYTHON_VERSION_312 && \
+    asdf reshim  python
+
+# Python2 dependencies are hardcoded because Python2 is
+# deprecated. Updating them to their latest versions may raise
+# incompatibility issues.
+RUN asdf local python $ROD_PYTHON_VERSION_27 && \
+    pip install --upgrade pip==20.3.4 && \
+    pip install --upgrade setuptools==44.1.1 && \
+    pip install --upgrade virtualenv==20.15.1 && \
+    pip install --upgrade wheel==0.37.1 && \
+    pip install --upgrade poetry==1.1.15
+
+# Install Python package versions
+RUN asdf local python $ROD_PYTHON_VERSION_310 && \
+    pip install --upgrade pip==$ROD_PIP_VERSION && \
+    pip install --upgrade setuptools==$ROD_SETUPTOOLS_VERSION && \
+    pip install --upgrade virtualenv==$ROD_VIRTUALENV_VERSION && \
+    pip install --upgrade wheel==$ROD_WHEEL_VERSION && \
+    pip install --upgrade poetry==$ROD_POETRY_VERSION && \
+    pip install --upgrade west==$ROD_WEST_VERSION
+
+RUN asdf local python $ROD_PYTHON_VERSION_312 && \
+    pip install --upgrade pip==$ROD_PIP_VERSION && \
+    pip install --upgrade setuptools==$ROD_SETUPTOOLS_VERSION && \
+    pip install --upgrade virtualenv==$ROD_VIRTUALENV_VERSION && \
+    pip install --upgrade wheel==$ROD_WHEEL_VERSION && \
+    pip install --upgrade poetry==$ROD_POETRY_VERSION && \
+    pip install --upgrade west==$ROD_WEST_VERSION
+
+# Adding labels for external usage
+LABEL python.version_27=$ROD_PYTHON_VERSION_27
+LABEL python.version_310=$ROD_PYTHON_VERSION_310
+LABEL python.version_312=$ROD_PYTHON_VERSION_312
+LABEL python.pip=$ROD_PIP_VERSION
+LABEL python.setuptools=$ROD_SETUPTOOLS_VERSION
+LABEL python.virtualenv=$ROD_VIRTUALENV_VERSION
+LABEL python.wheel=$ROD_WHEEL_VERSION
+LABEL python.poetry=$ROD_POETRY_VERSION
+LABEL python.west=$ROD_WEST_VERSION
+
+# Set default Python version
+RUN asdf local python $ROD_PYTHON_VERSION_312
+RUN asdf list  python
+
+# ############################################################################
+#
 # All architectures maintenance
 #
 # ############################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -250,7 +250,7 @@ RUN apt-get install -y \
     libreadline6-dev \
     libgmp-dev \
     libncurses5-dev \
-    libgdbm6 \
+    libgdbm6t64 \
     libgdbm-dev \
     libdb-dev \
     uuid-dev

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ README.md).
   - `west==1.2.0`
   - only-binary: `numpy`, `scipy`, `pandas`, `matplotlib`
 - PyPA pipx packages at Python 3.12:
+  - **argcomplete**: `pipx install argcomplete==3.5.0`
   - **poetry@1.8.3**: `pipx install --suffix=@1.8.3 poetry==1.8.3`
   - **poetry@1.7.1**: `pipx install --suffix=@1.7.1 poetry==1.7.1`
 - PyPA pipx packages at Python 3.10:

--- a/README.md
+++ b/README.md
@@ -18,13 +18,12 @@ README.md).
 
 ## Content
 
-- based on [Docker image definitions used by Read the
-  Docs](https://github.com/readthedocs/readthedocs-docker-images),
-  **ubuntu-24.04-2024.06.17**
-  - Ubuntu 24.04
-  - TeX Live 2023
+- based on [Ubuntu official Docker image](
+  https://github.com/docker-library/official-images),
+  **ubuntu:noble-20240904.1**
+  - Ubuntu 24.04.1 LTS
 - extend with:
-  - Ubuntu 24.04 package upgrade
+  - Ubuntu system package upgrade
   - locales for English unicode (`en_US.UTF-8`)
   - locales for German unicode (`de_DE.UTF-8`)
   - **Python 3.12.3** (`python3`, `pip3`)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ https://github.com/docker-library/official-images),
 - Docker image architectures:
   - Linux x86-64 (`linux/amd64`): https://hub.docker.com/r/amd64/ubuntu
   - ARMv7 32-bit (`linux/arm/v7`): https://hub.docker.com/r/arm32v7/ubuntu
+  - ARMv8 64-bit (`linux/arm64`): https://hub.docker.com/r/arm64v8/ubuntu
 
 ### Ubuntu system packages
 
@@ -49,26 +50,26 @@ https://github.com/docker-library/official-images),
 
 Based on [**asdf**](https://asdf-vm.com/) **0.14.1**:
 
-| runtime environments | environment variable      | `linux/amd64` | `linux/arm/v7` |
-| :------------------- | :------------------------ | :---: | :---: |
-| **Rust 1.81.0**      | `ROD_RUST_VERSION_2024`   | **X** | **X** |
-|   Rust 1.76.0        | `ROD_RUST_VERSION_2023`   |   X   |       |
-|   Rust 1.67.1        | `ROD_RUST_VERSION_2022`   |   X   |       |
-| **Golang 1.23.1**    | `ROD_GOLANG_VERSION_2024` | **X** | **X** |
-|   Golang 1.21.13     | `ROD_GOLANG_VERSION_2023` |   X   |       |
-|   Golang 1.19.13     | `ROD_GOLANG_VERSION_2022` |   X   |       |
-| **Node.js 22.9.0**   | `ROD_NODEJS_VERSION_22`   | **X** | **X** |
-|   Node.js 20.17.0    | `ROD_NODEJS_VERSION_20`   |   X   |       |
-|   Node.js 18.20.4    | `ROD_NODEJS_VERSION_18`   |   X   |       |
-| **Ruby 3.3.5**       | `ROD_RUBY_VERSION_33`     | **X** | **X** |
-|   Ruby 3.2.5         | `ROD_RUBY_VERSION_32`     |   X   |       |
-|   Ruby 3.1.6         | `ROD_RUBY_VERSION_31`     |   X   |       |
-| **Python 3.12.7**    | `ROD_PYTHON_VERSION_312`  | **X** | **X** |
-|   Python 3.10.15     | `ROD_PYTHON_VERSION_310`  |   X   |   X   |
-|   Python 2.7.18      | `ROD_PYTHON_VERSION_27`   |   X   |   X   |
-|   PyPy 3.10-7.3.17   | `ROD_PYPY_VERSION_3`      |   X   |       |
-|   PyPy 2.7-7.3.17    | `ROD_PYPY_VERSION_2`      |   X   |       |
-| **PyPA pipx 1.7.1**  | `ROD_PIPX_VERSION`        | **X** | **X** |
+| runtime environments | environment variable      | `linux/amd64` | `linux/arm/v7` | `linux/arm64` |
+| :------------------- | :------------------------ | :---: | :---: | :---: |
+| **Rust 1.81.0**      | `ROD_RUST_VERSION_2024`   | **X** | **X** | **X** |
+|   Rust 1.76.0        | `ROD_RUST_VERSION_2023`   |   X   |       |       |
+|   Rust 1.67.1        | `ROD_RUST_VERSION_2022`   |   X   |       |       |
+| **Golang 1.23.1**    | `ROD_GOLANG_VERSION_2024` | **X** | **X** | **X** |
+|   Golang 1.21.13     | `ROD_GOLANG_VERSION_2023` |   X   |       |       |
+|   Golang 1.19.13     | `ROD_GOLANG_VERSION_2022` |   X   |       |       |
+| **Node.js 22.9.0**   | `ROD_NODEJS_VERSION_22`   | **X** | **X** | **X** |
+|   Node.js 20.17.0    | `ROD_NODEJS_VERSION_20`   |   X   |       |       |
+|   Node.js 18.20.4    | `ROD_NODEJS_VERSION_18`   |   X   |       |       |
+| **Ruby 3.3.5**       | `ROD_RUBY_VERSION_33`     | **X** | **X** | **X** |
+|   Ruby 3.2.5         | `ROD_RUBY_VERSION_32`     |   X   |       |       |
+|   Ruby 3.1.6         | `ROD_RUBY_VERSION_31`     |   X   |       |       |
+| **Python 3.12.7**    | `ROD_PYTHON_VERSION_312`  | **X** | **X** | **X** |
+|   Python 3.10.15     | `ROD_PYTHON_VERSION_310`  |   X   |   X   |   X   |
+|   Python 2.7.18      | `ROD_PYTHON_VERSION_27`   |   X   |   X   |   X   |
+|   PyPy 3.10-7.3.17   | `ROD_PYPY_VERSION_3`      |   X   |       |       |
+|   PyPy 2.7-7.3.17    | `ROD_PYPY_VERSION_2`      |   X   |       |       |
+| **PyPA pipx 1.7.1**  | `ROD_PIPX_VERSION`        | **X** | **X** | **X** |
 
 **bold**: default runtime environment
 
@@ -76,18 +77,18 @@ Based on [**asdf**](https://asdf-vm.com/) **0.14.1**:
 
 Based on [Python Package Index](https://pypi.org/) with pip:
 
-| PyPI package name      | environment variable      | `linux/amd64` | `linux/arm/v7` |
-| :--------------------- | :------------------------ | :---: | :---: |
-| `pip==24.2`            | `ROD_PIP_VERSION`         |   X   |   X   |
-| `setuptools==75.1.0`   | `ROD_SETUPTOOLS_VERSION`  |   X   |   X   |
-| `virtualenv==20.26.6`  | `ROD_VIRTUALENV_VERSION`  |   X   |   X   |
-| `wheel==0.44.0`        | `ROD_WHEEL_VERSION`       |   X   |   X   |
-| `poetry==1.8.3`        | `ROD_POETRY_VERSION`      |   X   |   X   |
-| `west==1.2.0`          | `ROD_WEST_VERSION`        |   X   |   X   |
-| `numpy`                |                           | *(X)* |       |
-| `scipy`                |                           | *(X)* |       |
-| `pandas`               |                           | *(X)* |       |
-| `matplotlib`           |                           | *(X)* |       |
+| PyPI package name      | environment variable      | `linux/amd64` | `linux/arm/v7` | `linux/arm64` |
+| :--------------------- | :------------------------ | :---: | :---: | :---: |
+| `pip==24.2`            | `ROD_PIP_VERSION`         |   X   |   X   |   X   |
+| `setuptools==75.1.0`   | `ROD_SETUPTOOLS_VERSION`  |   X   |   X   |   X   |
+| `virtualenv==20.26.6`  | `ROD_VIRTUALENV_VERSION`  |   X   |   X   |   X   |
+| `wheel==0.44.0`        | `ROD_WHEEL_VERSION`       |   X   |   X   |   X   |
+| `poetry==1.8.3`        | `ROD_POETRY_VERSION`      |   X   |   X   |   X   |
+| `west==1.2.0`          | `ROD_WEST_VERSION`        |   X   |   X   |   X   |
+| `numpy`                |                           | *(X)* |       |       |
+| `scipy`                |                           | *(X)* |       |       |
+| `pandas`               |                           | *(X)* |       |       |
+| `matplotlib`           |                           | *(X)* |       |       |
 
 *(X)*: binary only and not in PyPy (CPython only)
 
@@ -95,17 +96,17 @@ Based on [Python Package Index](https://pypi.org/) with pip:
 
 Based on [Python Package Index](https://pypi.org/) with pip:
 
-| PyPI package name      | `linux/amd64` | `linux/arm/v7` |
-| :--------------------- | :---: | :---: |
-| `pip==20.3.4`          |   X   |   X   |
-| `setuptools==44.1.1`   |   X   |   X   |
-| `virtualenv==20.15.1`  |   X   |   X   |
-| `wheel==0.37.1`        |   X   |   X   |
-| `poetry==1.1.15`       |   X   |   X   |
-| `numpy==1.16.6`        | *(X)* |       |
-| `scipy==1.2.3`         | *(X)* |       |
-| `pandas==0.24.2`       | *(X)* |       |
-| `matplotlib==2.2.5`    | *(X)* |       |
+| PyPI package name      | `linux/amd64` | `linux/arm/v7` | `linux/arm64` |
+| :--------------------- | :---: | :---: | :---: |
+| `pip==20.3.4`          |   X   |   X   |   X   |
+| `setuptools==44.1.1`   |   X   |   X   |   X   |
+| `virtualenv==20.15.1`  |   X   |   X   |   X   |
+| `wheel==0.37.1`        |   X   |   X   |   X   |
+| `poetry==1.1.15`       |   X   |   X   |   X   |
+| `numpy==1.16.6`        | *(X)* |       |       |
+| `scipy==1.2.3`         | *(X)* |       |       |
+| `pandas==0.24.2`       | *(X)* |       |       |
+| `matplotlib==2.2.5`    | *(X)* |       |       |
 
 *(X)*: binary only and not in PyPy (CPython only)
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ https://github.com/docker-library/official-images),
 - [Ubuntu](https://hub.docker.com/_/ubuntu) 24.04.1 LTS
 - Docker image architectures:
   - Linux x86-64 (`linux/amd64`): https://hub.docker.com/r/amd64/ubuntu
+  - ARMv7 32-bit (`linux/arm/v7`): https://hub.docker.com/r/arm32v7/ubuntu
 
 ### Ubuntu system packages
 
@@ -48,26 +49,26 @@ https://github.com/docker-library/official-images),
 
 Based on [**asdf**](https://asdf-vm.com/) **0.14.1**:
 
-| runtime environments | environment variable      | `linux/amd64` |
-| :------------------- | :------------------------ | :---: |
-| **Rust 1.81.0**      | `ROD_RUST_VERSION_2024`   | **X** |
-|   Rust 1.76.0        | `ROD_RUST_VERSION_2023`   |   X   |
-|   Rust 1.67.1        | `ROD_RUST_VERSION_2022`   |   X   |
-| **Golang 1.23.1**    | `ROD_GOLANG_VERSION_2024` | **X** |
-|   Golang 1.21.13     | `ROD_GOLANG_VERSION_2023` |   X   |
-|   Golang 1.19.13     | `ROD_GOLANG_VERSION_2022` |   X   |
-| **Node.js 22.9.0**   | `ROD_NODEJS_VERSION_22`   | **X** |
-|   Node.js 20.17.0    | `ROD_NODEJS_VERSION_20`   |   X   |
-|   Node.js 18.20.4    | `ROD_NODEJS_VERSION_18`   |   X   |
-| **Ruby 3.3.5**       | `ROD_RUBY_VERSION_33`     | **X** |
-|   Ruby 3.2.5         | `ROD_RUBY_VERSION_32`     |   X   |
-|   Ruby 3.1.6         | `ROD_RUBY_VERSION_31`     |   X   |
-| **Python 3.12.7**    | `ROD_PYTHON_VERSION_312`  | **X** |
-|   Python 3.10.15     | `ROD_PYTHON_VERSION_310`  |   X   |
-|   Python 2.7.18      | `ROD_PYTHON_VERSION_27`   |   X   |
-|   PyPy 3.10-7.3.17   | `ROD_PYPY_VERSION_3`      |   X   |
-|   PyPy 2.7-7.3.17    | `ROD_PYPY_VERSION_2`      |   X   |
-| **PyPA pipx 1.7.1**  | `ROD_PIPX_VERSION`        | **X** |
+| runtime environments | environment variable      | `linux/amd64` | `linux/arm/v7` |
+| :------------------- | :------------------------ | :---: | :---: |
+| **Rust 1.81.0**      | `ROD_RUST_VERSION_2024`   | **X** | **X** |
+|   Rust 1.76.0        | `ROD_RUST_VERSION_2023`   |   X   |       |
+|   Rust 1.67.1        | `ROD_RUST_VERSION_2022`   |   X   |       |
+| **Golang 1.23.1**    | `ROD_GOLANG_VERSION_2024` | **X** | **X** |
+|   Golang 1.21.13     | `ROD_GOLANG_VERSION_2023` |   X   |       |
+|   Golang 1.19.13     | `ROD_GOLANG_VERSION_2022` |   X   |       |
+| **Node.js 22.9.0**   | `ROD_NODEJS_VERSION_22`   | **X** | **X** |
+|   Node.js 20.17.0    | `ROD_NODEJS_VERSION_20`   |   X   |       |
+|   Node.js 18.20.4    | `ROD_NODEJS_VERSION_18`   |   X   |       |
+| **Ruby 3.3.5**       | `ROD_RUBY_VERSION_33`     | **X** | **X** |
+|   Ruby 3.2.5         | `ROD_RUBY_VERSION_32`     |   X   |       |
+|   Ruby 3.1.6         | `ROD_RUBY_VERSION_31`     |   X   |       |
+| **Python 3.12.7**    | `ROD_PYTHON_VERSION_312`  | **X** | **X** |
+|   Python 3.10.15     | `ROD_PYTHON_VERSION_310`  |   X   |   X   |
+|   Python 2.7.18      | `ROD_PYTHON_VERSION_27`   |   X   |   X   |
+|   PyPy 3.10-7.3.17   | `ROD_PYPY_VERSION_3`      |   X   |       |
+|   PyPy 2.7-7.3.17    | `ROD_PYPY_VERSION_2`      |   X   |       |
+| **PyPA pipx 1.7.1**  | `ROD_PIPX_VERSION`        | **X** | **X** |
 
 **bold**: default runtime environment
 
@@ -75,18 +76,18 @@ Based on [**asdf**](https://asdf-vm.com/) **0.14.1**:
 
 Based on [Python Package Index](https://pypi.org/) with pip:
 
-| PyPI package name      | environment variable      | `linux/amd64` |
-| :--------------------- | :------------------------ | :---: |
-| `pip==24.2`            | `ROD_PIP_VERSION`         |   X   |
-| `setuptools==75.1.0`   | `ROD_SETUPTOOLS_VERSION`  |   X   |
-| `virtualenv==20.26.6`  | `ROD_VIRTUALENV_VERSION`  |   X   |
-| `wheel==0.44.0`        | `ROD_WHEEL_VERSION`       |   X   |
-| `poetry==1.8.3`        | `ROD_POETRY_VERSION`      |   X   |
-| `west==1.2.0`          | `ROD_WEST_VERSION`        |   X   |
-| `numpy`                |                           | *(X)* |
-| `scipy`                |                           | *(X)* |
-| `pandas`               |                           | *(X)* |
-| `matplotlib`           |                           | *(X)* |
+| PyPI package name      | environment variable      | `linux/amd64` | `linux/arm/v7` |
+| :--------------------- | :------------------------ | :---: | :---: |
+| `pip==24.2`            | `ROD_PIP_VERSION`         |   X   |   X   |
+| `setuptools==75.1.0`   | `ROD_SETUPTOOLS_VERSION`  |   X   |   X   |
+| `virtualenv==20.26.6`  | `ROD_VIRTUALENV_VERSION`  |   X   |   X   |
+| `wheel==0.44.0`        | `ROD_WHEEL_VERSION`       |   X   |   X   |
+| `poetry==1.8.3`        | `ROD_POETRY_VERSION`      |   X   |   X   |
+| `west==1.2.0`          | `ROD_WEST_VERSION`        |   X   |   X   |
+| `numpy`                |                           | *(X)* |       |
+| `scipy`                |                           | *(X)* |       |
+| `pandas`               |                           | *(X)* |       |
+| `matplotlib`           |                           | *(X)* |       |
 
 *(X)*: binary only and not in PyPy (CPython only)
 
@@ -94,17 +95,17 @@ Based on [Python Package Index](https://pypi.org/) with pip:
 
 Based on [Python Package Index](https://pypi.org/) with pip:
 
-| PyPI package name      | `linux/amd64` |
-| :--------------------- | :---: |
-| `pip==20.3.4`          |   X   |
-| `setuptools==44.1.1`   |   X   |
-| `virtualenv==20.15.1`  |   X   |
-| `wheel==0.37.1`        |   X   |
-| `poetry==1.1.15`       |   X   |
-| `numpy==1.16.6`        | *(X)* |
-| `scipy==1.2.3`         | *(X)* |
-| `pandas==0.24.2`       | *(X)* |
-| `matplotlib==2.2.5`    | *(X)* |
+| PyPI package name      | `linux/amd64` | `linux/arm/v7` |
+| :--------------------- | :---: | :---: |
+| `pip==20.3.4`          |   X   |   X   |
+| `setuptools==44.1.1`   |   X   |   X   |
+| `virtualenv==20.15.1`  |   X   |   X   |
+| `wheel==0.37.1`        |   X   |   X   |
+| `poetry==1.1.15`       |   X   |   X   |
+| `numpy==1.16.6`        | *(X)* |       |
+| `scipy==1.2.3`         | *(X)* |       |
+| `pandas==0.24.2`       | *(X)* |       |
+| `matplotlib==2.2.5`    | *(X)* |       |
 
 *(X)*: binary only and not in PyPy (CPython only)
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## Description
 
-This project creates the full-stack Docker image for processing [tutorial](
-https://bridle.tiac-systems.net/tutorials) and [training](
-https://bridle.tiac-systems.net/trainings) materials.
+This project creates the full-stack and multi-arch Docker images for processing
+[tutorial](https://bridle.tiac-systems.net/tutorials) and
+[training](https://bridle.tiac-systems.net/trainings) materials.
 
 ## Canonical source
 
@@ -18,70 +18,98 @@ README.md).
 
 ## Content
 
-- based on [Ubuntu official Docker image](
-  https://github.com/docker-library/official-images),
-  **ubuntu:noble-20240904.1**
-  - Ubuntu 24.04.1 LTS
-- extend with:
-  - Ubuntu system package upgrade
-  - locales for English unicode (`en_US.UTF-8`)
-  - locales for German unicode (`de_DE.UTF-8`)
-  - **Python 3.12.3** (`python3`, `pip3`)
-  - **LLVM C/C++** compiler **18.1.3** (`clang`, `clang++`)
-  - **GNU C/C++** compiler **13.2.0** (`gcc`, `g++`)
-  - **GNU Fortran 95** compiler **13.2.0** (`gfortran`)
-  - **OpenJDK 21** (`java`, `javac`)
-  - **SWIG 4.2.0** (`swig`)
-  - **TeX Live 2023** (`latex`, `xelatex`, `pdflatex`, `xindy`, `latexmk`)
-  - **ImageMagick 6.9.12.98** (`convert`)
-  - **Graphviz 2.43.0** (`dot`)
-  - **PlantUML 1.2020.2** (`plantuml`)
-  - **librsvg2-bin 2.58.0** (`rsvg-convert`)
-  - **poppler-utils 24.02.0** (`pdf2svg`, `pdftocairo`)
-- extend with asdf:
-  - **Rust**:
-    - **1.81.0**: `asdf local rust 1.81.0` (default)
-    - **1.76.0**: `asdf global rust 1.76.0`
-    - **1.67.1**: `asdf global rust 1.67.1`
-  - **Golang**:
-    - **1.23.1**: `asdf local golang 1.23.1` (default)
-    - **1.21.13**: `asdf global golang 1.21.13`
-    - **1.19.13**: `asdf global golang 1.19.13`
-  - **Nodejs**:
-    - **22.9.0**: `asdf local nodejs 22.9.0` (default)
-    - **20.17.0**: `asdf global nodejs 20.17.0`
-    - **18.20.4**: `asdf global nodejs 18.20.4`
-  - **Ruby**:
-    - **3.3.5**: `asdf local ruby 3.3.5` (default)
-    - **3.2.5**: `asdf global ruby 3.2.5`
-    - **3.1.6**: `asdf global ruby 3.1.6`
-  - **Python**:
-    - **3.12.7**: `asdf local python 3.12.7` (default)
-    - 3.11.10: security until October 2027, (deprecated)
-    - **3.10.15**: `asdf global python 3.10.15`
-    - **pypy3.10-7.3.17**: `asdf global python pypy3.10-7.3.17`
-    - 3.9.20: security until October 2025, (deprecated)
-    - 3.8.20: security until October 2024, (deprecated)
-    - 3.7.17: end-of-life since June 2023
-    - 3.6.15: end-of-life since December 2021
-    - 3.5.10: end-of-life since September 2020
-    - 3.4.10: end-of-life since March 2019
-    - 3.3.7: end-of-life since September 2017
-    - 3.2.6: end-of-life since February 2016
-    - 3.1.5: end-of-life since April 2012
-    - 3.0.1: end-of-life since June 2009
-    - **2.7.18**: `asdf global python 2.7.18` (obsolete)
-    - **pypy2.7-7.3.17**: `asdf global python pypy2.7-7.3.17`
-  - **PyPA pipx**:
-    - **1.7.1**: `asdf local pipx 1.7.1` (default)
-- Python packages:
-  - `pip==24.2`
-  - `setuptools==75.1.0`
-  - `virtualenv==20.26.6`
-  - `wheel==0.44.0`
-  - `poetry==1.8.3`
-  - `west==1.2.0`
-  - only-binary: `numpy`, `scipy`, `pandas`, `matplotlib`
+Based on [Ubuntu official Docker image](
+https://github.com/docker-library/official-images),
+**ubuntu:noble-20240904.1**:
+
+- [Ubuntu](https://hub.docker.com/_/ubuntu) 24.04.1 LTS
+- Docker image architectures:
+  - Linux x86-64 (`linux/amd64`): https://hub.docker.com/r/amd64/ubuntu
+
+### Ubuntu system packages
+
+- Ubuntu system package upgrade
+- locales for English unicode (`en_US.UTF-8`)
+- locales for German unicode (`de_DE.UTF-8`)
+- **Python 3.12.3** (`python3`, `pip3`)
+- **LLVM C/C++** compiler **18.1.3** (`clang`, `clang++`)
+- **GNU C/C++** compiler **13.2.0** (`gcc`, `g++`)
+- **GNU Fortran 95** compiler **13.2.0** (`gfortran`)
+- **OpenJDK 21** (`java`, `javac`)
+- **SWIG 4.2.0** (`swig`)
+- **TeX Live 2023** (`latex`, `xelatex`, `pdflatex`, `xindy`, `latexmk`)
+- **ImageMagick 6.9.12.98** (`convert`)
+- **Graphviz 2.43.0** (`dot`)
+- **PlantUML 1.2020.2** (`plantuml`)
+- **librsvg2-bin 2.58.0** (`rsvg-convert`)
+- **poppler-utils 24.02.0** (`pdf2svg`, `pdftocairo`)
+
+### Multiple runtime environments
+
+Based on [**asdf**](https://asdf-vm.com/) **0.14.1**:
+
+| runtime environments | environment variable      | `linux/amd64` |
+| :------------------- | :------------------------ | :---: |
+| **Rust 1.81.0**      | `ROD_RUST_VERSION_2024`   | **X** |
+|   Rust 1.76.0        | `ROD_RUST_VERSION_2023`   |   X   |
+|   Rust 1.67.1        | `ROD_RUST_VERSION_2022`   |   X   |
+| **Golang 1.23.1**    | `ROD_GOLANG_VERSION_2024` | **X** |
+|   Golang 1.21.13     | `ROD_GOLANG_VERSION_2023` |   X   |
+|   Golang 1.19.13     | `ROD_GOLANG_VERSION_2022` |   X   |
+| **Node.js 22.9.0**   | `ROD_NODEJS_VERSION_22`   | **X** |
+|   Node.js 20.17.0    | `ROD_NODEJS_VERSION_20`   |   X   |
+|   Node.js 18.20.4    | `ROD_NODEJS_VERSION_18`   |   X   |
+| **Ruby 3.3.5**       | `ROD_RUBY_VERSION_33`     | **X** |
+|   Ruby 3.2.5         | `ROD_RUBY_VERSION_32`     |   X   |
+|   Ruby 3.1.6         | `ROD_RUBY_VERSION_31`     |   X   |
+| **Python 3.12.7**    | `ROD_PYTHON_VERSION_312`  | **X** |
+|   Python 3.10.15     | `ROD_PYTHON_VERSION_310`  |   X   |
+|   Python 2.7.18      | `ROD_PYTHON_VERSION_27`   |   X   |
+|   PyPy 3.10-7.3.17   | `ROD_PYPY_VERSION_3`      |   X   |
+|   PyPy 2.7-7.3.17    | `ROD_PYPY_VERSION_2`      |   X   |
+| **PyPA pipx 1.7.1**  | `ROD_PIPX_VERSION`        | **X** |
+
+**bold**: default runtime environment
+
+### Python 3 packages
+
+Based on [Python Package Index](https://pypi.org/) with pip:
+
+| PyPI package name      | environment variable      | `linux/amd64` |
+| :--------------------- | :------------------------ | :---: |
+| `pip==24.2`            | `ROD_PIP_VERSION`         |   X   |
+| `setuptools==75.1.0`   | `ROD_SETUPTOOLS_VERSION`  |   X   |
+| `virtualenv==20.26.6`  | `ROD_VIRTUALENV_VERSION`  |   X   |
+| `wheel==0.44.0`        | `ROD_WHEEL_VERSION`       |   X   |
+| `poetry==1.8.3`        | `ROD_POETRY_VERSION`      |   X   |
+| `west==1.2.0`          | `ROD_WEST_VERSION`        |   X   |
+| `numpy`                |                           | *(X)* |
+| `scipy`                |                           | *(X)* |
+| `pandas`               |                           | *(X)* |
+| `matplotlib`           |                           | *(X)* |
+
+*(X)*: binary only and not in PyPy (CPython only)
+
+### Python 2 packages (obsolete)
+
+Based on [Python Package Index](https://pypi.org/) with pip:
+
+| PyPI package name      | `linux/amd64` |
+| :--------------------- | :---: |
+| `pip==20.3.4`          |   X   |
+| `setuptools==44.1.1`   |   X   |
+| `virtualenv==20.15.1`  |   X   |
+| `wheel==0.37.1`        |   X   |
+| `poetry==1.1.15`       |   X   |
+| `numpy==1.16.6`        | *(X)* |
+| `scipy==1.2.3`         | *(X)* |
+| `pandas==0.24.2`       | *(X)* |
+| `matplotlib==2.2.5`    | *(X)* |
+
+*(X)*: binary only and not in PyPy (CPython only)
+
+### PyPA pipx packages
+
 - PyPA pipx packages at Python 3.12:
   - **argcomplete**: `pipx install argcomplete==3.5.0`
   - **poetry@1.8.3**: `pipx install --suffix=@1.8.3 poetry==1.8.3`

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ https://github.com/docker-library/official-images),
   - ARMv8 64-bit (`linux/arm64`): https://hub.docker.com/r/arm64v8/ubuntu
   - RISC-V 64-bit (`linux/riscv64`): https://hub.docker.com/r/riscv64/ubuntu
   - IBM POWER8 (`linux/ppc64le`): https://hub.docker.com/r/ppc64le/ubuntu
+  - IBM z-Systems (`linux/s390x`): https://hub.docker.com/r/s390x/ubuntu
 
 ### Ubuntu system packages
 
@@ -52,26 +53,26 @@ https://github.com/docker-library/official-images),
 
 Based on [**asdf**](https://asdf-vm.com/) **0.14.1**:
 
-| runtime environments | environment variable      | `linux/amd64` | `linux/arm/v7` | `linux/arm64` | `linux/riscv64` | `linux/ppc64le` |
-| :------------------- | :------------------------ | :---: | :---: | :---: | :---: | :---: |
-| **Rust 1.81.0**      | `ROD_RUST_VERSION_2024`   | **X** | **X** | **X** | **X** | **X** |
-|   Rust 1.76.0        | `ROD_RUST_VERSION_2023`   |   X   |       |       |       |       |
-|   Rust 1.67.1        | `ROD_RUST_VERSION_2022`   |   X   |       |       |       |       |
-| **Golang 1.23.1**    | `ROD_GOLANG_VERSION_2024` | **X** | **X** | **X** | **X** | **X** |
-|   Golang 1.21.13     | `ROD_GOLANG_VERSION_2023` |   X   |       |       |       |       |
-|   Golang 1.19.13     | `ROD_GOLANG_VERSION_2022` |   X   |       |       |       |       |
-| **Node.js 22.9.0**   | `ROD_NODEJS_VERSION_22`   | **X** | **X** | **X** |       | **X** |
-|   Node.js 20.17.0    | `ROD_NODEJS_VERSION_20`   |   X   |       |       |       |       |
-|   Node.js 18.20.4    | `ROD_NODEJS_VERSION_18`   |   X   |       |       |       |       |
-| **Ruby 3.3.5**       | `ROD_RUBY_VERSION_33`     | **X** | **X** | **X** | **X** | **X** |
-|   Ruby 3.2.5         | `ROD_RUBY_VERSION_32`     |   X   |       |       |       |       |
-|   Ruby 3.1.6         | `ROD_RUBY_VERSION_31`     |   X   |       |       |       |       |
-| **Python 3.12.7**    | `ROD_PYTHON_VERSION_312`  | **X** | **X** | **X** | **X** | **X** |
-|   Python 3.10.15     | `ROD_PYTHON_VERSION_310`  |   X   |   X   |   X   |   X   |   X   |
-|   Python 2.7.18      | `ROD_PYTHON_VERSION_27`   |   X   |   X   |   X   |   X   |   X   |
-|   PyPy 3.10-7.3.17   | `ROD_PYPY_VERSION_3`      |   X   |       |       |       |       |
-|   PyPy 2.7-7.3.17    | `ROD_PYPY_VERSION_2`      |   X   |       |       |       |       |
-| **PyPA pipx 1.7.1**  | `ROD_PIPX_VERSION`        | **X** | **X** | **X** | **X** | **X** |
+| runtime environments | environment variable      | `linux/amd64` | `linux/arm/v7` | `linux/arm64` | `linux/riscv64` | `linux/ppc64le` | `linux/s390x` |
+| :------------------- | :------------------------ | :---: | :---: | :---: | :---: | :---: | :---: |
+| **Rust 1.81.0**      | `ROD_RUST_VERSION_2024`   | **X** | **X** | **X** | **X** | **X** | **X** |
+|   Rust 1.76.0        | `ROD_RUST_VERSION_2023`   |   X   |       |       |       |       |       |
+|   Rust 1.67.1        | `ROD_RUST_VERSION_2022`   |   X   |       |       |       |       |       |
+| **Golang 1.23.1**    | `ROD_GOLANG_VERSION_2024` | **X** | **X** | **X** | **X** | **X** |       |
+|   Golang 1.21.13     | `ROD_GOLANG_VERSION_2023` |   X   |       |       |       |       |       |
+|   Golang 1.19.13     | `ROD_GOLANG_VERSION_2022` |   X   |       |       |       |       |       |
+| **Node.js 22.9.0**   | `ROD_NODEJS_VERSION_22`   | **X** | **X** | **X** |       | **X** | **X** |
+|   Node.js 20.17.0    | `ROD_NODEJS_VERSION_20`   |   X   |       |       |       |       |       |
+|   Node.js 18.20.4    | `ROD_NODEJS_VERSION_18`   |   X   |       |       |       |       |       |
+| **Ruby 3.3.5**       | `ROD_RUBY_VERSION_33`     | **X** | **X** | **X** | **X** | **X** | **X** |
+|   Ruby 3.2.5         | `ROD_RUBY_VERSION_32`     |   X   |       |       |       |       |       |
+|   Ruby 3.1.6         | `ROD_RUBY_VERSION_31`     |   X   |       |       |       |       |       |
+| **Python 3.12.7**    | `ROD_PYTHON_VERSION_312`  | **X** | **X** | **X** | **X** | **X** | **X** |
+|   Python 3.10.15     | `ROD_PYTHON_VERSION_310`  |   X   |   X   |   X   |   X   |   X   |   X   |
+|   Python 2.7.18      | `ROD_PYTHON_VERSION_27`   |   X   |   X   |   X   |   X   |   X   |   X   |
+|   PyPy 3.10-7.3.17   | `ROD_PYPY_VERSION_3`      |   X   |       |       |       |       |       |
+|   PyPy 2.7-7.3.17    | `ROD_PYPY_VERSION_2`      |   X   |       |       |       |       |       |
+| **PyPA pipx 1.7.1**  | `ROD_PIPX_VERSION`        | **X** | **X** | **X** | **X** | **X** | **X** |
 
 **bold**: default runtime environment
 
@@ -81,18 +82,18 @@ The build of Node.js from source code fails on `linux/riscv64`!
 
 Based on [Python Package Index](https://pypi.org/) with pip:
 
-| PyPI package name      | environment variable      | `linux/amd64` | `linux/arm/v7` | `linux/arm64` | `linux/riscv64` | `linux/ppc64le` |
-| :--------------------- | :------------------------ | :---: | :---: | :---: | :---: | :---: |
-| `pip==24.2`            | `ROD_PIP_VERSION`         |   X   |   X   |   X   |   X   |   X   |
-| `setuptools==75.1.0`   | `ROD_SETUPTOOLS_VERSION`  |   X   |   X   |   X   |   X   |   X   |
-| `virtualenv==20.26.6`  | `ROD_VIRTUALENV_VERSION`  |   X   |   X   |   X   |   X   |   X   |
-| `wheel==0.44.0`        | `ROD_WHEEL_VERSION`       |   X   |   X   |   X   |   X   |   X   |
-| `poetry==1.8.3`        | `ROD_POETRY_VERSION`      |   X   |   X   |   X   |   X   |   X   |
-| `west==1.2.0`          | `ROD_WEST_VERSION`        |   X   |   X   |   X   |   X   |   X   |
-| `numpy`                |                           | *(X)* |       |       |       |       |
-| `scipy`                |                           | *(X)* |       |       |       |       |
-| `pandas`               |                           | *(X)* |       |       |       |       |
-| `matplotlib`           |                           | *(X)* |       |       |       |       |
+| PyPI package name      | environment variable      | `linux/amd64` | `linux/arm/v7` | `linux/arm64` | `linux/riscv64` | `linux/ppc64le` | `linux/s390x` |
+| :--------------------- | :------------------------ | :---: | :---: | :---: | :---: | :---: | :---: |
+| `pip==24.2`            | `ROD_PIP_VERSION`         |   X   |   X   |   X   |   X   |   X   |   X   |
+| `setuptools==75.1.0`   | `ROD_SETUPTOOLS_VERSION`  |   X   |   X   |   X   |   X   |   X   |   X   |
+| `virtualenv==20.26.6`  | `ROD_VIRTUALENV_VERSION`  |   X   |   X   |   X   |   X   |   X   |   X   |
+| `wheel==0.44.0`        | `ROD_WHEEL_VERSION`       |   X   |   X   |   X   |   X   |   X   |   X   |
+| `poetry==1.8.3`        | `ROD_POETRY_VERSION`      |   X   |   X   |   X   |   X   |   X   |   X   |
+| `west==1.2.0`          | `ROD_WEST_VERSION`        |   X   |   X   |   X   |   X   |   X   |   X   |
+| `numpy`                |                           | *(X)* |       |       |       |       |       |
+| `scipy`                |                           | *(X)* |       |       |       |       |       |
+| `pandas`               |                           | *(X)* |       |       |       |       |       |
+| `matplotlib`           |                           | *(X)* |       |       |       |       |       |
 
 *(X)*: binary only and not in PyPy (CPython only)
 
@@ -100,17 +101,17 @@ Based on [Python Package Index](https://pypi.org/) with pip:
 
 Based on [Python Package Index](https://pypi.org/) with pip:
 
-| PyPI package name      | `linux/amd64` | `linux/arm/v7` | `linux/arm64` | `linux/riscv64` | `linux/ppc64le` |
-| :--------------------- | :---: | :---: | :---: | :---: | :---: |
-| `pip==20.3.4`          |   X   |   X   |   X   |   X   |   X   |
-| `setuptools==44.1.1`   |   X   |   X   |   X   |   X   |   X   |
-| `virtualenv==20.15.1`  |   X   |   X   |   X   |   X   |   X   |
-| `wheel==0.37.1`        |   X   |   X   |   X   |   X   |   X   |
-| `poetry==1.1.15`       |   X   |   X   |   X   |   X   |   X   |
-| `numpy==1.16.6`        | *(X)* |       |       |       |       |
-| `scipy==1.2.3`         | *(X)* |       |       |       |       |
-| `pandas==0.24.2`       | *(X)* |       |       |       |       |
-| `matplotlib==2.2.5`    | *(X)* |       |       |       |       |
+| PyPI package name      | `linux/amd64` | `linux/arm/v7` | `linux/arm64` | `linux/riscv64` | `linux/ppc64le` | `linux/s390x` |
+| :--------------------- | :---: | :---: | :---: | :---: | :---: | :---: |
+| `pip==20.3.4`          |   X   |   X   |   X   |   X   |   X   |   X   |
+| `setuptools==44.1.1`   |   X   |   X   |   X   |   X   |   X   |   X   |
+| `virtualenv==20.15.1`  |   X   |   X   |   X   |   X   |   X   |   X   |
+| `wheel==0.37.1`        |   X   |   X   |   X   |   X   |   X   |   X   |
+| `poetry==1.1.15`       |   X   |   X   |   X   |   X   |   X   |   X   |
+| `numpy==1.16.6`        | *(X)* |       |       |       |       |       |
+| `scipy==1.2.3`         | *(X)* |       |       |       |       |       |
+| `pandas==0.24.2`       | *(X)* |       |       |       |       |       |
+| `matplotlib==2.2.5`    | *(X)* |       |       |       |       |       |
 
 *(X)*: binary only and not in PyPy (CPython only)
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ https://github.com/docker-library/official-images),
   - Linux x86-64 (`linux/amd64`): https://hub.docker.com/r/amd64/ubuntu
   - ARMv7 32-bit (`linux/arm/v7`): https://hub.docker.com/r/arm32v7/ubuntu
   - ARMv8 64-bit (`linux/arm64`): https://hub.docker.com/r/arm64v8/ubuntu
+  - RISC-V 64-bit (`linux/riscv64`): https://hub.docker.com/r/riscv64/ubuntu
 
 ### Ubuntu system packages
 
@@ -50,45 +51,47 @@ https://github.com/docker-library/official-images),
 
 Based on [**asdf**](https://asdf-vm.com/) **0.14.1**:
 
-| runtime environments | environment variable      | `linux/amd64` | `linux/arm/v7` | `linux/arm64` |
-| :------------------- | :------------------------ | :---: | :---: | :---: |
-| **Rust 1.81.0**      | `ROD_RUST_VERSION_2024`   | **X** | **X** | **X** |
-|   Rust 1.76.0        | `ROD_RUST_VERSION_2023`   |   X   |       |       |
-|   Rust 1.67.1        | `ROD_RUST_VERSION_2022`   |   X   |       |       |
-| **Golang 1.23.1**    | `ROD_GOLANG_VERSION_2024` | **X** | **X** | **X** |
-|   Golang 1.21.13     | `ROD_GOLANG_VERSION_2023` |   X   |       |       |
-|   Golang 1.19.13     | `ROD_GOLANG_VERSION_2022` |   X   |       |       |
-| **Node.js 22.9.0**   | `ROD_NODEJS_VERSION_22`   | **X** | **X** | **X** |
-|   Node.js 20.17.0    | `ROD_NODEJS_VERSION_20`   |   X   |       |       |
-|   Node.js 18.20.4    | `ROD_NODEJS_VERSION_18`   |   X   |       |       |
-| **Ruby 3.3.5**       | `ROD_RUBY_VERSION_33`     | **X** | **X** | **X** |
-|   Ruby 3.2.5         | `ROD_RUBY_VERSION_32`     |   X   |       |       |
-|   Ruby 3.1.6         | `ROD_RUBY_VERSION_31`     |   X   |       |       |
-| **Python 3.12.7**    | `ROD_PYTHON_VERSION_312`  | **X** | **X** | **X** |
-|   Python 3.10.15     | `ROD_PYTHON_VERSION_310`  |   X   |   X   |   X   |
-|   Python 2.7.18      | `ROD_PYTHON_VERSION_27`   |   X   |   X   |   X   |
-|   PyPy 3.10-7.3.17   | `ROD_PYPY_VERSION_3`      |   X   |       |       |
-|   PyPy 2.7-7.3.17    | `ROD_PYPY_VERSION_2`      |   X   |       |       |
-| **PyPA pipx 1.7.1**  | `ROD_PIPX_VERSION`        | **X** | **X** | **X** |
+| runtime environments | environment variable      | `linux/amd64` | `linux/arm/v7` | `linux/arm64` | `linux/riscv64` |
+| :------------------- | :------------------------ | :---: | :---: | :---: | :---: |
+| **Rust 1.81.0**      | `ROD_RUST_VERSION_2024`   | **X** | **X** | **X** | **X** |
+|   Rust 1.76.0        | `ROD_RUST_VERSION_2023`   |   X   |       |       |       |
+|   Rust 1.67.1        | `ROD_RUST_VERSION_2022`   |   X   |       |       |       |
+| **Golang 1.23.1**    | `ROD_GOLANG_VERSION_2024` | **X** | **X** | **X** | **X** |
+|   Golang 1.21.13     | `ROD_GOLANG_VERSION_2023` |   X   |       |       |       |
+|   Golang 1.19.13     | `ROD_GOLANG_VERSION_2022` |   X   |       |       |       |
+| **Node.js 22.9.0**   | `ROD_NODEJS_VERSION_22`   | **X** | **X** | **X** |       |
+|   Node.js 20.17.0    | `ROD_NODEJS_VERSION_20`   |   X   |       |       |       |
+|   Node.js 18.20.4    | `ROD_NODEJS_VERSION_18`   |   X   |       |       |       |
+| **Ruby 3.3.5**       | `ROD_RUBY_VERSION_33`     | **X** | **X** | **X** | **X** |
+|   Ruby 3.2.5         | `ROD_RUBY_VERSION_32`     |   X   |       |       |       |
+|   Ruby 3.1.6         | `ROD_RUBY_VERSION_31`     |   X   |       |       |       |
+| **Python 3.12.7**    | `ROD_PYTHON_VERSION_312`  | **X** | **X** | **X** | **X** |
+|   Python 3.10.15     | `ROD_PYTHON_VERSION_310`  |   X   |   X   |   X   |   X   |
+|   Python 2.7.18      | `ROD_PYTHON_VERSION_27`   |   X   |   X   |   X   |   X   |
+|   PyPy 3.10-7.3.17   | `ROD_PYPY_VERSION_3`      |   X   |       |       |       |
+|   PyPy 2.7-7.3.17    | `ROD_PYPY_VERSION_2`      |   X   |       |       |       |
+| **PyPA pipx 1.7.1**  | `ROD_PIPX_VERSION`        | **X** | **X** | **X** | **X** |
 
 **bold**: default runtime environment
+
+The build of Node.js from source code fails on `linux/riscv64`!
 
 ### Python 3 packages
 
 Based on [Python Package Index](https://pypi.org/) with pip:
 
-| PyPI package name      | environment variable      | `linux/amd64` | `linux/arm/v7` | `linux/arm64` |
-| :--------------------- | :------------------------ | :---: | :---: | :---: |
-| `pip==24.2`            | `ROD_PIP_VERSION`         |   X   |   X   |   X   |
-| `setuptools==75.1.0`   | `ROD_SETUPTOOLS_VERSION`  |   X   |   X   |   X   |
-| `virtualenv==20.26.6`  | `ROD_VIRTUALENV_VERSION`  |   X   |   X   |   X   |
-| `wheel==0.44.0`        | `ROD_WHEEL_VERSION`       |   X   |   X   |   X   |
-| `poetry==1.8.3`        | `ROD_POETRY_VERSION`      |   X   |   X   |   X   |
-| `west==1.2.0`          | `ROD_WEST_VERSION`        |   X   |   X   |   X   |
-| `numpy`                |                           | *(X)* |       |       |
-| `scipy`                |                           | *(X)* |       |       |
-| `pandas`               |                           | *(X)* |       |       |
-| `matplotlib`           |                           | *(X)* |       |       |
+| PyPI package name      | environment variable      | `linux/amd64` | `linux/arm/v7` | `linux/arm64` | `linux/riscv64` |
+| :--------------------- | :------------------------ | :---: | :---: | :---: | :---: |
+| `pip==24.2`            | `ROD_PIP_VERSION`         |   X   |   X   |   X   |   X   |
+| `setuptools==75.1.0`   | `ROD_SETUPTOOLS_VERSION`  |   X   |   X   |   X   |   X   |
+| `virtualenv==20.26.6`  | `ROD_VIRTUALENV_VERSION`  |   X   |   X   |   X   |   X   |
+| `wheel==0.44.0`        | `ROD_WHEEL_VERSION`       |   X   |   X   |   X   |   X   |
+| `poetry==1.8.3`        | `ROD_POETRY_VERSION`      |   X   |   X   |   X   |   X   |
+| `west==1.2.0`          | `ROD_WEST_VERSION`        |   X   |   X   |   X   |   X   |
+| `numpy`                |                           | *(X)* |       |       |       |
+| `scipy`                |                           | *(X)* |       |       |       |
+| `pandas`               |                           | *(X)* |       |       |       |
+| `matplotlib`           |                           | *(X)* |       |       |       |
 
 *(X)*: binary only and not in PyPy (CPython only)
 
@@ -96,17 +99,17 @@ Based on [Python Package Index](https://pypi.org/) with pip:
 
 Based on [Python Package Index](https://pypi.org/) with pip:
 
-| PyPI package name      | `linux/amd64` | `linux/arm/v7` | `linux/arm64` |
-| :--------------------- | :---: | :---: | :---: |
-| `pip==20.3.4`          |   X   |   X   |   X   |
-| `setuptools==44.1.1`   |   X   |   X   |   X   |
-| `virtualenv==20.15.1`  |   X   |   X   |   X   |
-| `wheel==0.37.1`        |   X   |   X   |   X   |
-| `poetry==1.1.15`       |   X   |   X   |   X   |
-| `numpy==1.16.6`        | *(X)* |       |       |
-| `scipy==1.2.3`         | *(X)* |       |       |
-| `pandas==0.24.2`       | *(X)* |       |       |
-| `matplotlib==2.2.5`    | *(X)* |       |       |
+| PyPI package name      | `linux/amd64` | `linux/arm/v7` | `linux/arm64` | `linux/riscv64` |
+| :--------------------- | :---: | :---: | :---: | :---: |
+| `pip==20.3.4`          |   X   |   X   |   X   |   X   |
+| `setuptools==44.1.1`   |   X   |   X   |   X   |   X   |
+| `virtualenv==20.15.1`  |   X   |   X   |   X   |   X   |
+| `wheel==0.37.1`        |   X   |   X   |   X   |   X   |
+| `poetry==1.1.15`       |   X   |   X   |   X   |   X   |
+| `numpy==1.16.6`        | *(X)* |       |       |       |
+| `scipy==1.2.3`         | *(X)* |       |       |       |
+| `pandas==0.24.2`       | *(X)* |       |       |       |
+| `matplotlib==2.2.5`    | *(X)* |       |       |       |
 
 *(X)*: binary only and not in PyPy (CPython only)
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ https://github.com/docker-library/official-images),
   - ARMv7 32-bit (`linux/arm/v7`): https://hub.docker.com/r/arm32v7/ubuntu
   - ARMv8 64-bit (`linux/arm64`): https://hub.docker.com/r/arm64v8/ubuntu
   - RISC-V 64-bit (`linux/riscv64`): https://hub.docker.com/r/riscv64/ubuntu
+  - IBM POWER8 (`linux/ppc64le`): https://hub.docker.com/r/ppc64le/ubuntu
 
 ### Ubuntu system packages
 
@@ -51,26 +52,26 @@ https://github.com/docker-library/official-images),
 
 Based on [**asdf**](https://asdf-vm.com/) **0.14.1**:
 
-| runtime environments | environment variable      | `linux/amd64` | `linux/arm/v7` | `linux/arm64` | `linux/riscv64` |
-| :------------------- | :------------------------ | :---: | :---: | :---: | :---: |
-| **Rust 1.81.0**      | `ROD_RUST_VERSION_2024`   | **X** | **X** | **X** | **X** |
-|   Rust 1.76.0        | `ROD_RUST_VERSION_2023`   |   X   |       |       |       |
-|   Rust 1.67.1        | `ROD_RUST_VERSION_2022`   |   X   |       |       |       |
-| **Golang 1.23.1**    | `ROD_GOLANG_VERSION_2024` | **X** | **X** | **X** | **X** |
-|   Golang 1.21.13     | `ROD_GOLANG_VERSION_2023` |   X   |       |       |       |
-|   Golang 1.19.13     | `ROD_GOLANG_VERSION_2022` |   X   |       |       |       |
-| **Node.js 22.9.0**   | `ROD_NODEJS_VERSION_22`   | **X** | **X** | **X** |       |
-|   Node.js 20.17.0    | `ROD_NODEJS_VERSION_20`   |   X   |       |       |       |
-|   Node.js 18.20.4    | `ROD_NODEJS_VERSION_18`   |   X   |       |       |       |
-| **Ruby 3.3.5**       | `ROD_RUBY_VERSION_33`     | **X** | **X** | **X** | **X** |
-|   Ruby 3.2.5         | `ROD_RUBY_VERSION_32`     |   X   |       |       |       |
-|   Ruby 3.1.6         | `ROD_RUBY_VERSION_31`     |   X   |       |       |       |
-| **Python 3.12.7**    | `ROD_PYTHON_VERSION_312`  | **X** | **X** | **X** | **X** |
-|   Python 3.10.15     | `ROD_PYTHON_VERSION_310`  |   X   |   X   |   X   |   X   |
-|   Python 2.7.18      | `ROD_PYTHON_VERSION_27`   |   X   |   X   |   X   |   X   |
-|   PyPy 3.10-7.3.17   | `ROD_PYPY_VERSION_3`      |   X   |       |       |       |
-|   PyPy 2.7-7.3.17    | `ROD_PYPY_VERSION_2`      |   X   |       |       |       |
-| **PyPA pipx 1.7.1**  | `ROD_PIPX_VERSION`        | **X** | **X** | **X** | **X** |
+| runtime environments | environment variable      | `linux/amd64` | `linux/arm/v7` | `linux/arm64` | `linux/riscv64` | `linux/ppc64le` |
+| :------------------- | :------------------------ | :---: | :---: | :---: | :---: | :---: |
+| **Rust 1.81.0**      | `ROD_RUST_VERSION_2024`   | **X** | **X** | **X** | **X** | **X** |
+|   Rust 1.76.0        | `ROD_RUST_VERSION_2023`   |   X   |       |       |       |       |
+|   Rust 1.67.1        | `ROD_RUST_VERSION_2022`   |   X   |       |       |       |       |
+| **Golang 1.23.1**    | `ROD_GOLANG_VERSION_2024` | **X** | **X** | **X** | **X** | **X** |
+|   Golang 1.21.13     | `ROD_GOLANG_VERSION_2023` |   X   |       |       |       |       |
+|   Golang 1.19.13     | `ROD_GOLANG_VERSION_2022` |   X   |       |       |       |       |
+| **Node.js 22.9.0**   | `ROD_NODEJS_VERSION_22`   | **X** | **X** | **X** |       | **X** |
+|   Node.js 20.17.0    | `ROD_NODEJS_VERSION_20`   |   X   |       |       |       |       |
+|   Node.js 18.20.4    | `ROD_NODEJS_VERSION_18`   |   X   |       |       |       |       |
+| **Ruby 3.3.5**       | `ROD_RUBY_VERSION_33`     | **X** | **X** | **X** | **X** | **X** |
+|   Ruby 3.2.5         | `ROD_RUBY_VERSION_32`     |   X   |       |       |       |       |
+|   Ruby 3.1.6         | `ROD_RUBY_VERSION_31`     |   X   |       |       |       |       |
+| **Python 3.12.7**    | `ROD_PYTHON_VERSION_312`  | **X** | **X** | **X** | **X** | **X** |
+|   Python 3.10.15     | `ROD_PYTHON_VERSION_310`  |   X   |   X   |   X   |   X   |   X   |
+|   Python 2.7.18      | `ROD_PYTHON_VERSION_27`   |   X   |   X   |   X   |   X   |   X   |
+|   PyPy 3.10-7.3.17   | `ROD_PYPY_VERSION_3`      |   X   |       |       |       |       |
+|   PyPy 2.7-7.3.17    | `ROD_PYPY_VERSION_2`      |   X   |       |       |       |       |
+| **PyPA pipx 1.7.1**  | `ROD_PIPX_VERSION`        | **X** | **X** | **X** | **X** | **X** |
 
 **bold**: default runtime environment
 
@@ -80,18 +81,18 @@ The build of Node.js from source code fails on `linux/riscv64`!
 
 Based on [Python Package Index](https://pypi.org/) with pip:
 
-| PyPI package name      | environment variable      | `linux/amd64` | `linux/arm/v7` | `linux/arm64` | `linux/riscv64` |
-| :--------------------- | :------------------------ | :---: | :---: | :---: | :---: |
-| `pip==24.2`            | `ROD_PIP_VERSION`         |   X   |   X   |   X   |   X   |
-| `setuptools==75.1.0`   | `ROD_SETUPTOOLS_VERSION`  |   X   |   X   |   X   |   X   |
-| `virtualenv==20.26.6`  | `ROD_VIRTUALENV_VERSION`  |   X   |   X   |   X   |   X   |
-| `wheel==0.44.0`        | `ROD_WHEEL_VERSION`       |   X   |   X   |   X   |   X   |
-| `poetry==1.8.3`        | `ROD_POETRY_VERSION`      |   X   |   X   |   X   |   X   |
-| `west==1.2.0`          | `ROD_WEST_VERSION`        |   X   |   X   |   X   |   X   |
-| `numpy`                |                           | *(X)* |       |       |       |
-| `scipy`                |                           | *(X)* |       |       |       |
-| `pandas`               |                           | *(X)* |       |       |       |
-| `matplotlib`           |                           | *(X)* |       |       |       |
+| PyPI package name      | environment variable      | `linux/amd64` | `linux/arm/v7` | `linux/arm64` | `linux/riscv64` | `linux/ppc64le` |
+| :--------------------- | :------------------------ | :---: | :---: | :---: | :---: | :---: |
+| `pip==24.2`            | `ROD_PIP_VERSION`         |   X   |   X   |   X   |   X   |   X   |
+| `setuptools==75.1.0`   | `ROD_SETUPTOOLS_VERSION`  |   X   |   X   |   X   |   X   |   X   |
+| `virtualenv==20.26.6`  | `ROD_VIRTUALENV_VERSION`  |   X   |   X   |   X   |   X   |   X   |
+| `wheel==0.44.0`        | `ROD_WHEEL_VERSION`       |   X   |   X   |   X   |   X   |   X   |
+| `poetry==1.8.3`        | `ROD_POETRY_VERSION`      |   X   |   X   |   X   |   X   |   X   |
+| `west==1.2.0`          | `ROD_WEST_VERSION`        |   X   |   X   |   X   |   X   |   X   |
+| `numpy`                |                           | *(X)* |       |       |       |       |
+| `scipy`                |                           | *(X)* |       |       |       |       |
+| `pandas`               |                           | *(X)* |       |       |       |       |
+| `matplotlib`           |                           | *(X)* |       |       |       |       |
 
 *(X)*: binary only and not in PyPy (CPython only)
 
@@ -99,17 +100,17 @@ Based on [Python Package Index](https://pypi.org/) with pip:
 
 Based on [Python Package Index](https://pypi.org/) with pip:
 
-| PyPI package name      | `linux/amd64` | `linux/arm/v7` | `linux/arm64` | `linux/riscv64` |
-| :--------------------- | :---: | :---: | :---: | :---: |
-| `pip==20.3.4`          |   X   |   X   |   X   |   X   |
-| `setuptools==44.1.1`   |   X   |   X   |   X   |   X   |
-| `virtualenv==20.15.1`  |   X   |   X   |   X   |   X   |
-| `wheel==0.37.1`        |   X   |   X   |   X   |   X   |
-| `poetry==1.1.15`       |   X   |   X   |   X   |   X   |
-| `numpy==1.16.6`        | *(X)* |       |       |       |
-| `scipy==1.2.3`         | *(X)* |       |       |       |
-| `pandas==0.24.2`       | *(X)* |       |       |       |
-| `matplotlib==2.2.5`    | *(X)* |       |       |       |
+| PyPI package name      | `linux/amd64` | `linux/arm/v7` | `linux/arm64` | `linux/riscv64` | `linux/ppc64le` |
+| :--------------------- | :---: | :---: | :---: | :---: | :---: |
+| `pip==20.3.4`          |   X   |   X   |   X   |   X   |   X   |
+| `setuptools==44.1.1`   |   X   |   X   |   X   |   X   |   X   |
+| `virtualenv==20.15.1`  |   X   |   X   |   X   |   X   |   X   |
+| `wheel==0.37.1`        |   X   |   X   |   X   |   X   |   X   |
+| `poetry==1.1.15`       |   X   |   X   |   X   |   X   |   X   |
+| `numpy==1.16.6`        | *(X)* |       |       |       |       |
+| `scipy==1.2.3`         | *(X)* |       |       |       |       |
+| `pandas==0.24.2`       | *(X)* |       |       |       |       |
+| `matplotlib==2.2.5`    | *(X)* |       |       |       |       |
 
 *(X)*: binary only and not in PyPy (CPython only)
 


### PR DESCRIPTION
- use official Docker image Ubuntu 24.04.1 LTS "Noble" with tag [20240904.1](https://hub.docker.com/_/ubuntu)
- asdf-vm version 0.14.1 with updates from: https://github.com/asdf-vm/asdf
- asdf-vm plugins for:
  - pipx:   https://github.com/yozachar/asdf-pipx
  - python: https://github.com/asdf-community/asdf-python
  - nodejs: https://github.com/asdf-vm/asdf-nodejs
  - rust:   https://github.com/code-lever/asdf-rust
  - golang: https://github.com/asdf-community/asdf-golang
  - ruby:   https://github.com/asdf-vm/asdf-ruby
- enable shell completions for PyPA pipx